### PR TITLE
Fix excluded rules in shield stack

### DIFF
--- a/cdk/lib/shield-stack.ts
+++ b/cdk/lib/shield-stack.ts
@@ -190,7 +190,7 @@ export class ShieldStack extends Stack {
 
         let ruleActionOverrides = []
 
-        for (let excludedRule in rule.excludedRules) {
+        for (let excludedRule of rule.excludedRules) {
           let excludedRuleObj = {
             actionToUse: {
               count: {}


### PR DESCRIPTION
The same fix as in https://github.com/vrk-kpa/opendata/pull/2185