### PR TITLE
REKDAT-116: Hide user capacity in organization lists

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/organization/snippets/organization_list.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/organization/snippets/organization_list.html
@@ -2,7 +2,7 @@
 <ul class="organization-list list-unstyled">
   {% block organization_list_inner %}
   {% for organization in organizations %}
-    {% snippet "organization/snippets/organization_item.html", organization=organization, position=loop.index, show_capacity=show_capacity %}
+    {% snippet "organization/snippets/organization_item.html", organization=organization, position=loop.index, show_capacity=False %}
   {% endfor %}
    {% endblock %}
 </ul>


### PR DESCRIPTION
- Don't show user role (capacity) in organization listings even if asked to