### PR TITLE
REKDAT-116: Hide `member` user capacity in API/UIs

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/action.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/action.py
@@ -18,3 +18,16 @@ def user_create(original_action, context, data_dict):
             toolkit.get_action('group_member_create')(context, member_data)
 
     return result
+
+
+# Remove "member" capacity from UIs
+@toolkit.chained_action
+def member_roles_list(original_action, context, data_dict):
+    roles = original_action(context, data_dict)
+
+    group_type = data_dict.get('group_type', 'organization')
+    if group_type == 'organization':
+        result = [role for role in roles
+                  if role['value'] != 'member']
+
+    return result

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
@@ -164,7 +164,8 @@ class RestrictedDataPlugin(plugins.SingletonPlugin, DefaultTranslation):
 
     def get_actions(self):
         return {
-            'user_create': action.user_create
+            'user_create': action.user_create,
+            'member_roles_list': action.member_roles_list,
         }
 
 


### PR DESCRIPTION
- Override `member_roles_list` to hide `member` user capacity
- Used by member creation UIs