### PR TITLE
REKDAT-111: Remove license from DCAT-AP profile and dataset sidebar

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/dcat.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/dcat.py
@@ -101,7 +101,6 @@ class RestrictedDataDCATAPProfile(EuropeanDCATAP2Profile):
                 ('temporal_granularity', DCAT.temporalResolution),
             ])
 
-            self._add_triple_from_dict(dataset_dict, distribution, DCT.license, 'license_id')
             self._add_triple_from_dict(resource_dict, distribution, ADMS.status, 'maturity')
             self._add_triple_from_dict(resource_dict, distribution, DCAT.endpointUrl, 'endpoint_url', _type=URIRef)
             self._add_triple_from_dict(resource_dict, distribution, DCT.conformsTo, 'position_info')

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/package/read.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/package/read.html
@@ -27,7 +27,6 @@
   {% endblock categories %}
 
   {% block package_license %}
-    {{ super() }}
   {% endblock package_license %}
 
   {% block package_social %}


### PR DESCRIPTION
- Remove setting dct:license for distributions in DCAT-AP profile
- Remove lincese information from dataset sidebar