### PR TITLE
REKDAT-131: Added migration tool and 1.4.1->1.5.0 content migration

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/cli/cli.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/cli/cli.py
@@ -1,9 +1,13 @@
 import click
+import sys
+from ckan.plugins import toolkit
 from . import categories
+from .migrate import Migrate, plan_to_path
+from .migrations import migrations
 
 
 def get_commands():
-    return [restricteddata]
+    return [restricteddata, content]
 
 
 @click.group()
@@ -29,3 +33,50 @@ def delete_default_categories(context, dryrun: bool, purge: bool) -> None:
     click.secho("delete_default_categories - BEGIN")
     categories.delete(context, dryrun, purge)
 
+
+@click.group()
+def content():
+    'Content modification tools'
+    pass
+
+
+@content.command()
+@click.pass_context
+@click.argument('current_version')
+@click.argument('target_version')
+@click.option(u'--dryrun', is_flag=True)
+@click.option(u'--path-index', type=int)
+def migrate(ctx, current_version, target_version, dryrun, path_index):
+    'Migrates site content from one version to another'
+    m = Migrate()
+
+    for v1, v2, step in migrations():
+        m.add(v1, v2, step)
+
+    plans = m.plan(current_version, target_version)
+
+    if not plans:
+        click.secho(f'No migration paths found from {current_version} to {target_version}')
+        sys.exit(1)
+    elif len(plans) > 1:
+        if path_index is None:
+            click.secho(f'Multiple migration paths found from {current_version} to {target_version}.')
+            click.secho('Run this command again with the option --path-index <your selection>')
+            for i, plan in enumerate(plans):
+                click.secho('{}: {}'.format(i, ' -> '.join(plan_to_path(plan))))
+            sys.exit(1)
+
+        plan = plans[int(path_index)]
+    else:
+        plan = plans[0]
+
+    click.secho('Using migration path: {}'.format(' -> '.join(plan_to_path(plan))))
+
+    if dryrun:
+        click.secho('Performing a dry run')
+
+    for v1, v2, step in plan:
+        click.secho('Migrating from {} to {}'.format(v1, v2))
+        step(ctx, toolkit.config, dryrun, echo=click.secho)
+
+    click.secho('Finished migration successfully')

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/cli/migrate.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/cli/migrate.py
@@ -1,0 +1,115 @@
+import itertools
+from builtins import range
+from builtins import object
+from collections import deque
+from pprint import pformat
+from ckan.plugins import toolkit
+
+get_action = toolkit.get_action
+
+
+def breadth_first_search(graph, start, end):
+    visited = set()
+    queue = deque([(start, [start])])
+    results = []
+    while queue:
+        node, path = queue.popleft()
+        if node == end:
+            results.append(path)
+            continue
+        if node in visited:
+            continue
+        visited.add(node)
+        for child in graph.get(node, []):
+            queue.append((child, path + [child]))
+    return results
+
+
+class Migrate(object):
+    def __init__(self):
+        self.callbacks = {}
+        self.graph = {}
+
+    def add(self, version_from, version_to, callback):
+        self.graph.setdefault(version_from, []).append(version_to)
+        self.callbacks.setdefault(version_from, {})[version_to] = callback
+
+    def plan(self, version_from, version_to):
+        paths = breadth_first_search(self.graph, version_from, version_to)
+        plans = []
+        for path in paths:
+            plan = [(path[i-1], path[i], self.callbacks[path[i-1]][path[i]])
+                    for i in range(1, len(path))]
+            plans.append(plan)
+        return plans
+
+
+def plan_to_path(plan):
+    return [plan[0][0]] + [v2 for v1, v2, step in plan]
+
+
+def apply_patches(package_patches=[], resource_patches=[], organization_patches=[], dryrun=False, echo=print):
+    if not (package_patches or resource_patches or organization_patches):
+        echo('No patches to process.')
+    elif dryrun:
+        if package_patches:
+            echo('Package patches:')
+            echo('\n'.join(pformat(p) for p in package_patches))
+        if resource_patches:
+            echo('Resource patches:')
+            echo('\n'.join(pformat(p) for p in resource_patches))
+        if organization_patches:
+            echo('Organization patches:')
+            echo('\n'.join(pformat(p) for p in organization_patches))
+    else:
+        package_patch = get_action('package_patch')
+        resource_patch = get_action('resource_patch')
+        organization_patch = get_action('organization_patch')
+        context = {'ignore_auth': True}
+        for patch in package_patches:
+            try:
+                echo("Migrating package %s" % patch['id'])
+                package_patch(context, patch)
+            except toolkit.ValidationError as e:
+                echo("Migration failed for package %s reason:" % patch['id'])
+                echo(e)
+        for patch in resource_patches:
+            try:
+                echo("Migrating resource %s" % patch['id'])
+                resource_patch(context, patch)
+            except toolkit.ValidationError as e:
+                echo("Migration failed for resource %s, reason" % patch['id'])
+                echo(e)
+        for patch in organization_patches:
+            try:
+                echo("Migrating organization %s" % patch['id'])
+                organization_patch(context, patch)
+            except toolkit.ValidationError as e:
+                echo("Migration failed for organization %s reason:" % patch['id'])
+                echo(e)
+
+
+def package_generator(query='*:*', page_size=1000, context={'ignore_auth': True}, dataset_type='dataset'):
+    package_search = get_action('package_search')
+
+    # Loop through all items. Each page has {page_size} items.
+    # Stop iteration when all items have been looped.
+    for index in itertools.count(start=0, step=page_size):
+        data_dict = {'include_private': True, 'rows': page_size, 'q': query, 'start': index,
+                     'fq': '+dataset_type:' + dataset_type}
+        data = package_search(context, data_dict)
+        packages = data.get('results', [])
+        for package in packages:
+            yield package
+
+        # Stop iteration all query results have been looped through
+        if data["count"] < (index + page_size):
+            return
+
+
+def org_generator():
+    context = {'ignore_auth': True}
+    org_list = get_action('organization_list')
+    orgs = org_list(context, {'all_fields': True, 'include_extras': True})
+    for org in orgs:
+        yield org

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/cli/migrations.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/cli/migrations.py
@@ -1,0 +1,28 @@
+import ckan.plugins.toolkit as toolkit
+from .migrate import apply_patches, package_generator
+get_action = toolkit.get_action
+
+
+#
+# Migrations
+#
+
+def migrations():
+    return [('1.4.1', '1.5.0', migrate_1_4_1_to_1_5_0),
+            ]
+
+
+#
+# Migration step functions
+#
+
+def no_changes(*args, **kwargs):
+    pass
+
+
+def migrate_1_4_1_to_1_5_0(ctx, config, dryrun, echo=print):
+    from ckanext.restricteddata.dcat import FREQUENCY_MAP
+    package_patches = [{'id': package['id'], 'update_frequency': None}
+                       for package in package_generator()
+                       if package.get('update_frequency') not in FREQUENCY_MAP]
+    apply_patches(package_patches=package_patches, dryrun=dryrun, echo=echo)


### PR DESCRIPTION
- Ported migrate.py from api-catalog
- Added migration for mapping update frequency to new limited selection
- Added CLI tool for applying migrations