### PR TITLE
REKDAT-73: Add termination protection to DB/FS stacks

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -115,7 +115,8 @@ const DatabaseStackDev = new DatabaseStack(app, 'DatabaseStack-dev', {
   backups: true,
   backupPlan: BackupStackDev.backupPlan,
   cacheNodeType: 'cache.t3.micro',
-  numCacheNodes: 1
+  numCacheNodes: 1,
+  terminationProtection: true
 })
 
 const LoadBalancerStackDev = new LoadBalancerStack(app, 'LoadBalancerStack-dev', {
@@ -175,7 +176,8 @@ const FileSystemStackDev = new FileSystemStack(app, 'FilesystemStack-dev', {
   },
   envProps: envProps,
   environment: devStackProps.environment,
-  vpc: VpcStackDev.vpc
+  vpc: VpcStackDev.vpc,
+  terminationProtection: true
 })
 
 
@@ -323,7 +325,8 @@ const DatabaseStackProd = new DatabaseStack(app, 'DatabaseStack-prod', {
   backups: true,
   backupPlan: BackupStackProd.backupPlan,
   cacheNodeType: 'cache.t3.micro',
-  numCacheNodes: 1
+  numCacheNodes: 1,
+  terminationProtection: true
 })
 
 const LoadBalancerStackProd = new LoadBalancerStack(app, 'LoadBalancerStack-prod', {
@@ -375,7 +378,8 @@ const FileSystemStackProd = new FileSystemStack(app, 'FilesystemStack-prod', {
   },
   envProps: envProps,
   environment: prodStackProps.environment,
-  vpc: VpcStackProd.vpc
+  vpc: VpcStackProd.vpc,
+  terminationProtection: true
 })
 
 

--- a/cdk/lib/database-stack-props.ts
+++ b/cdk/lib/database-stack-props.ts
@@ -7,5 +7,6 @@ export interface DatabaseStackProps extends CommonStackProps {
     backupPlan: aws_backup.BackupPlan;
     cacheNodeType: string;
     numCacheNodes: number;
+    terminationProtection: boolean;
 }
 

--- a/cdk/lib/efs-stack-props.ts
+++ b/cdk/lib/efs-stack-props.ts
@@ -5,4 +5,5 @@ import {aws_backup} from "aws-cdk-lib";
 
 export interface EfsStackProps extends CommonStackProps {
   vpc: ec2.IVpc;
+  terminationProtection: boolean;
 }

--- a/cdk/lib/shield-stack.ts
+++ b/cdk/lib/shield-stack.ts
@@ -11,7 +11,6 @@ import {
 import {Construct} from "constructs";
 
 import {ShieldStackProps} from "./shield-stack-props";
-import any = jasmine.any;
 
 
 export class ShieldStack extends Stack {


### PR DESCRIPTION
- Set termination protection for stacks: 
  - DatabaseStackDev
  - DatabaseStackProd
  - FileSystemStackDev
  - FileSystemStackProd
- Remove unnecessary reference to `jasmine`