### PR TITLE
REKDAT-98: Add MonitoringStack to send zulip notifications on container restarts

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -18,6 +18,7 @@ import {SolrStack} from "../lib/solr-stack";
 import {FileSystemStack} from "../lib/filesystem-stack";
 import {CkanStack} from "../lib/ckan-stack";
 import {ShieldStack} from "../lib/shield-stack";
+import {MonitoringStack} from '../lib/monitoring-stack';
 
 const app = new cdk.App();
 
@@ -280,6 +281,16 @@ const ShieldStackDev = new ShieldStack(app, 'ShieldStack-dev', {
   vpc: VpcStackDev.vpc
 })
 
+const MonitoringStackDev = new MonitoringStack(app, 'MonitoringStack-dev', {
+  sendToZulipLambda: LambdaStackDev.sendToZulipLambda,
+  envProps: envProps,
+  env: {
+    account: devStackProps.account,
+    region: devStackProps.region,
+  },
+  environment: devStackProps.environment,
+  vpc: VpcStackDev.vpc
+});
 
 // Production
 
@@ -481,3 +492,14 @@ const ShieldStackProd = new ShieldStack(app, 'ShieldStack-prod', {
   requestSampleAllTrafficEnabled: false,
   vpc: VpcStackProd.vpc
 })
+
+const MonitoringStackProd = new MonitoringStack(app, 'MonitoringStack-prod', {
+  sendToZulipLambda: LambdaStackProd.sendToZulipLambda,
+  envProps: envProps,
+  env: {
+    account: prodStackProps.account,
+    region: prodStackProps.region,
+  },
+  environment: prodStackProps.environment,
+  vpc: VpcStackProd.vpc
+});

--- a/cdk/lib/lambda-stack.ts
+++ b/cdk/lib/lambda-stack.ts
@@ -5,9 +5,12 @@ import {Construct} from "constructs";
 import {LambdaStackProps} from "./lambda-stack-props";
 import {Credentials} from "aws-cdk-lib/aws-rds";
 import {Key} from "aws-cdk-lib/aws-kms";
+import { SendToZulip } from "./send-to-zulip";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 
 export class LambdaStack extends Stack {
   readonly ckanCredentials: Credentials;
+  readonly sendToZulipLambda: NodejsFunction;
   constructor(scope: Construct, id: string, props: LambdaStackProps ) {
     super(scope, id, props);
 
@@ -26,5 +29,17 @@ export class LambdaStack extends Stack {
     })
 
     this.ckanCredentials = Credentials.fromSecret(createDatabases.ckanSecret);
+
+    const sendToZulip = new SendToZulip(this, 'send-to-zulip', {
+      zulipApiUser: 'avoindata-bot@turina.dvv.fi',
+      zulipApiUrl: 'turina.dvv.fi',
+      zulipStream: 'DGA',
+      zulipTopic: 'Container restarts',
+      envProps: props.envProps,
+      env: props.env,
+      environment: props.environment,
+      vpc: props.vpc
+    });
+    this.sendToZulipLambda = sendToZulip.lambda;
   }
 }

--- a/cdk/lib/monitoring-stack-props.ts
+++ b/cdk/lib/monitoring-stack-props.ts
@@ -1,0 +1,7 @@
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { CommonStackProps } from './common-stack-props';
+
+export interface MonitoringStackProps extends CommonStackProps {
+  sendToZulipLambda: NodejsFunction
+}
+

--- a/cdk/lib/monitoring-stack.ts
+++ b/cdk/lib/monitoring-stack.ts
@@ -1,0 +1,37 @@
+import { Stack } from 'aws-cdk-lib';
+import { MonitoringStackProps } from './monitoring-stack-props';
+
+import * as events from 'aws-cdk-lib/aws-events';
+import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
+import * as logs from 'aws-cdk-lib/aws-logs';
+
+import { Construct } from 'constructs';
+
+export class MonitoringStack extends Stack {
+  constructor(scope: Construct, id: string, props: MonitoringStackProps) {
+    super(scope, id, props);
+
+    // Task health check failure log group
+    const taskHealthCheckFailLogGroup = new logs.LogGroup(this, 'taskHealthCheckFailedGroup', {
+      logGroupName: 'taskHealthCheckFailedGroup'
+    });
+
+    // Eventbridge rule to send 
+    const sendToDeveloperZulipTarget = new eventsTargets.LambdaFunction(props.sendToZulipLambda, {});
+    const taskHealthCheckFailLogGroupTarget = new eventsTargets.CloudWatchLogGroup(taskHealthCheckFailLogGroup);
+
+    new events.Rule(this, 'taskHealthCheckFailedRule', {
+      description: 'Rule for forwarding container health check failures to zulip',
+      eventPattern: {
+        source: ['aws.ecs'],
+        detail: {
+          desiredStatus: ['STOPPED'],
+          stoppedReason: [{wildcard: '*health*'}]
+        }
+      },
+      targets: [sendToDeveloperZulipTarget, taskHealthCheckFailLogGroupTarget],
+    })
+
+  }
+}
+

--- a/cdk/lib/send-to-zulip-props.ts
+++ b/cdk/lib/send-to-zulip-props.ts
@@ -1,0 +1,9 @@
+import {CommonStackProps} from "./common-stack-props";
+
+export interface SendToZulipProps extends CommonStackProps {
+  zulipApiUser: string,
+  zulipApiUrl: string,
+  zulipStream: string,
+  zulipTopic: string
+}
+

--- a/cdk/lib/send-to-zulip.function.ts
+++ b/cdk/lib/send-to-zulip.function.ts
@@ -1,0 +1,79 @@
+import {Handler} from 'aws-lambda';
+import {GetSecretValueCommand, SecretsManagerClient} from "@aws-sdk/client-secrets-manager";
+import * as https from 'https';
+import FormData = require('form-data');
+
+const { ZULIP_API_URL, ZULIP_API_USER, ZULIP_API_KEY_SECRET, ZULIP_STREAM, ZULIP_TOPIC } = process.env;
+
+function eventMessage(event: any) {
+  const {detail} = event;
+  if(detail?.eventName) {
+    // Generic event
+    const {resources} = event;
+    return `${detail?.eventName}: ${resources?.join(', ')}`;
+  } else if(detail?.stoppedReason) {
+    // Container stopped event
+    const {taskArn, group, stoppedReason} = detail;
+    return `${taskArn} (${group}): ${stoppedReason}`;
+  } else {
+    return 'Unknown message type';
+  }
+}
+export const handler: Handler = async (event: any) => {
+  if(!ZULIP_API_URL || !ZULIP_API_USER || !ZULIP_API_KEY_SECRET ||
+     !ZULIP_STREAM || !ZULIP_TOPIC) {
+    return {
+      statusCode: 500,
+      body: 'Missing configuration values',
+    }
+  }
+
+  const secretsManagerClient = new SecretsManagerClient({region: "eu-west-1"});
+  const command = new GetSecretValueCommand({
+    SecretId: ZULIP_API_KEY_SECRET
+  });
+  const response = await secretsManagerClient.send(command);
+  const zulipApiKey = response.SecretString;
+
+  const message = eventMessage(event);
+  
+  const data = new FormData();
+  data.append('type', 'stream');
+  data.append('to', ZULIP_STREAM);
+  data.append('topic', ZULIP_TOPIC);
+  data.append('content', message);
+
+  const options: https.RequestOptions = {
+    hostname: ZULIP_API_URL,
+    port: 443,
+    path: '/api/v1/messages',
+    method: 'POST',
+    auth: `${ZULIP_API_USER}:${zulipApiKey}`,
+    headers: data.getHeaders(),
+  };
+
+  await new Promise((resolve, reject) => {
+    const req = https.request(options, (res: any) => {
+      if(res.statusCode != 200) {
+        console.log('Response from Zulip API:', res.statusCode);
+        res.on('data', (chunk: any) => {
+          console.log(chunk.toString());
+        }).on('end', () => {
+          resolve(res);
+        });
+      } else {
+        resolve(res);
+      }
+    }).on('error', (error: any) => {
+      console.error('Error sending message to Zulip:', error);
+      reject(error);
+    });
+    data.pipe(req);
+    req.end();
+  });
+
+  return {
+    statusCode: 200,
+    body: 'Message sent to Zulip',
+  };
+};

--- a/cdk/lib/send-to-zulip.ts
+++ b/cdk/lib/send-to-zulip.ts
@@ -1,0 +1,25 @@
+import {Construct} from "constructs";
+import {NodejsFunction} from "aws-cdk-lib/aws-lambda-nodejs";
+import {SendToZulipProps} from "./send-to-zulip-props";
+import * as sm from 'aws-cdk-lib/aws-secretsmanager';
+
+export class SendToZulip extends Construct {
+  readonly lambda: NodejsFunction;
+  constructor(scope: Construct, id: string, props: SendToZulipProps) {
+    super(scope, id);
+
+    // Task restart zulip reporting
+    const zulipSecret = sm.Secret.fromSecretNameV2(this, 'sZulipSecret', `/${props.environment}/zulip_api_key`);
+
+    this.lambda = new NodejsFunction(this, 'function', {
+      environment: {
+        ZULIP_API_USER: props.zulipApiUser,
+        ZULIP_API_KEY_SECRET: zulipSecret.secretName,
+        ZULIP_API_URL: props.zulipApiUrl,
+        ZULIP_STREAM: props.zulipStream,
+        ZULIP_TOPIC: props.zulipTopic
+      }
+    });
+    zulipSecret.grantRead(this.lambda);
+  }
+}

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -12,6 +12,7 @@
         "aws-cdk-lib": "2.92.0",
         "constructs": "^10.0.0",
         "dotenv": "^16.3.1",
+        "form-data": "^4.0.0",
         "knex": "^2.4.2",
         "pg": "^8.11.0",
         "source-map-support": "^0.5.21"
@@ -2385,6 +2386,11 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/aws-cdk": {
       "version": "2.92.0",
       "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.92.0.tgz",
@@ -3083,6 +3089,17 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -3168,6 +3185,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-newline": {
@@ -3386,6 +3411,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -4559,6 +4597,25 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -7588,6 +7645,11 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "aws-cdk": {
       "version": "2.92.0",
       "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.92.0.tgz",
@@ -8056,6 +8118,14 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -8115,6 +8185,11 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -8264,6 +8339,16 @@
       "requires": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
+      }
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
     "fs.realpath": {
@@ -9146,6 +9231,19 @@
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
+      }
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
       }
     },
     "mimic-fn": {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -25,6 +25,7 @@
     "aws-cdk-lib": "2.92.0",
     "constructs": "^10.0.0",
     "dotenv": "^16.3.1",
+    "form-data": "^4.0.0",
     "knex": "^2.4.2",
     "pg": "^8.11.0",
     "source-map-support": "^0.5.21"


### PR DESCRIPTION
- Add `SendToZulip` lambda to `LambdaStack`
- Add `MonitoringStack`
  - Forwards ECS container restarts to a log group
  - Invokes `SendToZulip` for messages in the log group