### PR TITLE
Restart prod containers workflow

### DIFF
--- a/.github/workflows/restart_prod_containers.yml
+++ b/.github/workflows/restart_prod_containers.yml
@@ -1,0 +1,26 @@
+name: Restart Prod containers
+
+on:
+  workflow_dispatch:
+
+jobs:
+  restart-prod:
+    name: restart prod containers
+    runs-on: ubuntu-latest
+    environment: prod
+    permissions:
+      id-token: write
+    strategy:
+      matrix:
+        container: ["ckan", "ckanCron"]
+    steps:
+      - name: configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4.0.1
+        with:
+          role-to-assume: ${{ secrets.AWS_PROD_DEPLOY_ROLE }}
+          role-session-name: github-actions
+          aws-region: eu-north-1
+
+      - name: Restart containers
+        run: |
+          aws ecs update-service --cluster ${{ secrets.cluster }} --service ${{ matrix.container }} --force-new-deployment

--- a/cloudformation/github-actions-stack.yml
+++ b/cloudformation/github-actions-stack.yml
@@ -31,7 +31,7 @@ Parameters:
     AllowedValues: [true, false]
 
 Conditions:
-  CreateOIDCProvider: !Equals 
+  CreateOIDCProvider: !Equals
     - !Ref OIDCProviderArn
     - ""
   ShouldCreateBuildRole: !Equals ['true', !Ref CreateBuildRole]
@@ -61,6 +61,13 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: "ecr:GetAuthorizationToken"
+                Resource: "*"
+        - PolicyName: ecs-update-service
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: "ecs:UpdateService"
                 Resource: "*"
         - PolicyName: cfn-access
           PolicyDocument:


### PR DESCRIPTION
Add similar workflow as restart dev containers and adds missing permission to cloudformation templates.