### PR TITLE
REKDAT-147: add missing arrow to select components

### DIFF
--- a/assets/src/scss/input.scss
+++ b/assets/src/scss/input.scss
@@ -52,7 +52,7 @@ select {
     align-items: center;
     gap: 10px;
     align-self: stretch;
-
+    appearance: auto;
     &::placeholder {
       font-style: italic;
     }

--- a/assets/src/scss/input.scss
+++ b/assets/src/scss/input.scss
@@ -52,7 +52,7 @@ select {
     align-items: center;
     gap: 10px;
     align-self: stretch;
-    appearance: auto;
+
     &::placeholder {
       font-style: italic;
     }

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/macros/form/select.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/macros/form/select.html
@@ -32,11 +32,13 @@ options     - A list/tuple of fields to be used as <options>.
 
     {%- set extra_html = caller() if caller -%}
     {% call input_block(id or name, label or name, error, classes, extra_html=extra_html, is_required=is_required, description=description) %}
-    <select id="{{ id or name }}" name="{{ name }}" {{ attributes(attrs) }}>
-      {% for option in options %}
-      <option value="{{ option.value }}"
-              {% if option.value == selected %}selected{% endif %}>{{ option.text or option.value }}</option>
-      {% endfor %}
-    </select>
+    <div class="select-wrapper">
+      <select id="{{ id or name }}" name="{{ name }}" {{ attributes(attrs) }}>
+        {% for option in options %}
+        <option value="{{ option.value }}"
+                {% if option.value == selected %}selected{% endif %}>{{ option.text or option.value }}</option>
+        {% endfor %}
+      </select>
+    </div>
     {% endcall %}
     {% endmacro %}


### PR DESCRIPTION
Before:
![image](https://github.com/vrk-kpa/restricteddata/assets/830663/dba4d147-4d2d-4683-8d42-249c3cebcb6a)

After:
![image](https://github.com/vrk-kpa/restricteddata/assets/830663/c90969dc-522a-41b8-a5f5-d8b491c49e0f)

