### PR TITLE
REKDAT-146: Add missing border to organization list

### DIFF
--- a/assets/src/scss/ckan/organizations.scss
+++ b/assets/src/scss/ckan/organizations.scss
@@ -7,6 +7,7 @@
 
   .organization-item {
     padding: 20px;
+    border-bottom: rd.$border-light;
     .organization-content {
       .organization-heading {
         font-size: inherit;
@@ -15,5 +16,9 @@
         }
       }
     }
+  }
+
+  &:last-child {
+    border-bottom: none;
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,7 +87,7 @@ export const lintStyles = () => {
 
 // Preprocess our ckan sass
 const ckanSass = () => {
-  return src(paths.src.scss + "ckan/**/*.scss", { sourcemaps: true })
+  return src(paths.src.scss + "ckan/main.scss", { sourcemaps: true })
     .pipe(sass({ includePaths: ["node_modules"], outputStyle: 'expanded', sourceMap: true }).on('error', sass.logError))
     .pipe(cleancss({ keepBreaks: false }))
     .pipe(concat('restricteddata.css'))


### PR DESCRIPTION
Adds missing border to organization list items:
![image](https://github.com/vrk-kpa/restricteddata/assets/830663/343ecffc-e189-407a-8a59-15ae5c60a03f)


Changes sass build to build only main.scss file as it includes other files. Before the resulting css had all the rules twice, this change removes duplicates. Other alternative would be to remove main.scss file all together.