### PR TITLE
REKDAT-137: Limit dataset group assignment to users who can update both

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/helpers.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/helpers.py
@@ -1,4 +1,3 @@
-
 from ckan import model
 from ckan.common import c
 from ckan.plugins import toolkit
@@ -207,3 +206,19 @@ def get_translated_logo(language: str):
     else:
         [path, extension] = site_logo.rsplit('.', 1)
         return f'{path}_{language}.{extension}'
+
+
+def get_assignable_groups_for_package(pkg_dict):
+    context = {'model': model, 'session': model.Session, 'user': c.user}
+
+    try:
+        toolkit.check_access('package_update', context, {'id': pkg_dict['id']})
+    except toolkit.NotAuthorized:
+        return []
+
+    groups = scheming_category_list(None)
+    package_group_ids = set(g['name'] for g in pkg_dict.get('groups', []))
+
+    return [{'name': g['value'], 'title_translated': g['label']}
+            for g in groups
+            if g['value'] not in package_group_ids]

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/auth.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/auth.py
@@ -1,0 +1,23 @@
+from ckan.plugins import toolkit
+
+@toolkit.chained_auth_function
+def member_create(next_auth, context, data_dict):
+    if data_dict['object_type'] == 'package':
+        try:
+            toolkit.check_access('package_update', context, {'id': data_dict['object']})
+        except toolkit.NotAuthorized:
+            return {'success': False,
+                    'message': 'Only dataset owners can modify dataset groups'}
+
+    return next_auth(context, data_dict)
+
+@toolkit.chained_auth_function
+def member_delete(next_auth, context, data_dict):
+    if data_dict['object_type'] == 'package':
+        try:
+            toolkit.check_access('package_update', context, {'id': data_dict['object']})
+        except toolkit.NotAuthorized:
+            return {'success': False,
+                    'message': 'Only dataset owners can modify dataset groups'}
+
+    return next_auth(context, data_dict)

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
@@ -12,7 +12,7 @@ from ckanext.restricteddata.cli import cli
 from collections import OrderedDict
 
 from . import helpers, validators, converters, views
-from .logic import action
+from .logic import action, auth
 
 log = logging.getLogger(__name__)
 ResourceDict = Dict[str, Any]
@@ -29,6 +29,7 @@ class RestrictedDataPlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.IBlueprint)
     plugins.implements(plugins.IFacets, inherit=True)
     plugins.implements(plugins.IActions, inherit=True)
+    plugins.implements(plugins.IAuthFunctions)
 
     # IConfigurer
 
@@ -56,6 +57,7 @@ class RestrictedDataPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'check_group_selected': helpers.check_group_selected,
             'build_nav_main': helpers.build_nav_main,
             'get_translated_logo': helpers.get_translated_logo,
+            'get_assignable_groups_for_package': helpers.get_assignable_groups_for_package,
         }
 
     # IValidators:
@@ -165,6 +167,14 @@ class RestrictedDataPlugin(plugins.SingletonPlugin, DefaultTranslation):
         return {
             'user_create': action.user_create,
             'member_roles_list': action.member_roles_list,
+        }
+
+    # IAuthFunctions
+
+    def get_auth_functions(self):
+        return {
+            'member_create': auth.member_create,
+            'member_delete': auth.member_delete,
         }
 
 

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/group/snippets/group_item.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/group/snippets/group_item.html
@@ -1,0 +1,41 @@
+{% ckan_extends %}
+{% block item_inner %}
+  {% block image %}
+    <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ group.name }}" class="media-image img-fluid">
+  {% endblock %}
+  {% block title %}
+    <h2 class="media-heading">{{ group.display_name }}</h2>
+  {% endblock %}
+  {% block description %}
+    {% if group.description %}
+      <p class="media-description">{{ h.markdown_extract(group.description, extract_length=80) }}</p>
+    {% endif %}
+  {% endblock %}
+  {% block datasets %}
+    {% if group.package_count %}
+      <strong class="count">{{ ungettext('{num} Dataset', '{num} Datasets', group.package_count).format(num=group.package_count) }}</strong><br/>
+    {% elif group.package_count == 0 %}
+      <span class="count">{{ _('0 Datasets') }}</span><br/>
+    {% endif %}
+  {% endblock %}
+  {% block members %}
+    {% if 'member_count' in group and group.member_count %}
+      <strong class="count">{{ ungettext('{num} Member', '{num} Members', group.member_count).format(num=group.member_count) }}</strong>
+    {% else %}
+      {# <span class="count">{{ _('0 Members') }}</span> #}
+    {% endif %}
+  {% endblock %}
+  {% block capacity %}
+    {% if show_capacity and group.capacity %}
+    <p><span class="label label-default">{{ h.roles_translated().get(group.capacity, group.capacity) }}</span></p>
+    {% endif %}
+  {% endblock %}
+  {% block link %}
+  <a href="{{ url }}" title="{{ _('View {name}').format(name=group.display_name) }}" class="media-view">
+    <span>{{ _('View {name}').format(name=group.display_name) }}</span>
+  </a>
+  {% endblock %}
+  {% if group.user_member and allow_delete %}
+    <input name="group_remove.{{ group.id }}" value="{{ _('Remove') }}" type="submit" class="btn btn-danger btn-sm media-edit" title="{{ _('Remove dataset from this group') }}"/>
+  {% endif %}
+{% endblock %}

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/group/snippets/group_list.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/group/snippets/group_list.html
@@ -1,0 +1,6 @@
+{% ckan_extends %}
+{% block group_list_inner %}
+  {% for group in groups %}
+    {% snippet "group/snippets/group_item.html", group=group, position=loop.index, show_capacity=show_capacity, allow_delete=allow_delete %}
+  {% endfor %}
+{% endblock %}

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/package/group_list.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/package/group_list.html
@@ -1,0 +1,29 @@
+{% ckan_extends %}
+
+{% block primary_content_inner %}
+  <h2 class="hide-heading">{{ h.humanize_entity_type('group', default_group_type, 'page title') or _('Groups') }}</h2>
+
+  {# Added package_update requirement #}
+  {% set assignable_groups = h.get_assignable_groups_for_package(pkg_dict) %}
+  {% if assignable_groups %}
+    <form class="add-to-group" method="post">
+      {{ h.csrf_input() }}
+      <select id="field-add_group" name="group_added" data-module="autocomplete">
+        {% for group in assignable_groups %}
+          <option value="{{ group.name }}">{{ h.get_translated(group, 'title') }}</option>
+        {% endfor %}
+      </select>
+      <button type="submit" class="btn btn-primary" title="{{ _('Associate this group with this dataset') }}">{{ _('Add to group') }}</button>
+    </form>
+  {% endif %}
+
+  {% if pkg_dict.groups %}
+    <form method="post">
+      {{ h.csrf_input() }}
+      {% set allow_group_delete = h.check_access('package_update', {'id': pkg.id }) %}
+      {% snippet 'group/snippets/group_list.html', groups=pkg_dict.groups, allow_delete=allow_group_delete %}
+    </form>
+  {% else %}
+    <p class="empty">{{ h.humanize_entity_type('group', default_group_type, 'no associated label') or _('There are no groups associated with this dataset') }}</p>
+  {% endif %}
+{% endblock %}

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_helpers.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_helpers.py
@@ -1,0 +1,42 @@
+import pytest
+
+# import ckanext.restricteddata.plugin as plugin
+from ckan.plugins import toolkit
+from ckan.tests.factories import Dataset, Sysadmin, Organization, User, Group
+from .utils import minimal_dataset_with_one_resource_fields
+
+import ckanext.restricteddata.helpers as helpers
+
+
+@pytest.mark.usefixtures("clean_db", "with_plugins")
+class TestGetAssignableGroupsForPackageHelper(object):
+    @pytest.mark.usefixtures("with_request_context")
+    def test_get_assignable_groups_for_package_helper_with_non_maintainer(self, app):
+        _g = Group()
+        some_user = User()
+        org = Organization()
+
+        dataset_fields = minimal_dataset_with_one_resource_fields(Sysadmin())
+        dataset_fields['owner_org'] = org['id']
+        d = Dataset(**dataset_fields)
+
+        toolkit.g.user = some_user['name']
+        groups = helpers.get_assignable_groups_for_package(d)
+        assert groups == []
+
+    @pytest.mark.usefixtures("with_request_context")
+    def test_get_assignable_groups_for_package_helper_with_maintainer(self, app):
+        g1 = Group()
+        g2 = Group()
+        maintainer = User()
+        org = Organization(user=maintainer)
+
+        dataset_fields = minimal_dataset_with_one_resource_fields(Sysadmin())
+        dataset_fields['owner_org'] = org['id']
+        dataset_fields['groups'] = [{'name': g1['name']}]
+        d = Dataset(**dataset_fields)
+
+        toolkit.g.user = maintainer['name']
+        [unassigned_group] = helpers.get_assignable_groups_for_package(d)
+        assert unassigned_group['name'] == g2['name']
+


### PR DESCRIPTION
- Added helper for fetching groups the user can modify that the provided package is not a member of if the user can also modify the package
- Update group list templates to use the new helper
- Remove delete button from group list items if the user doesn't have permission to update the related package
- Remove showing 0 group members if the count is not provided
- Override member_create and member_delete auth functions to disallow adding/removing package from a group if the user doesn't have authorization to update both