### PR TITLE
codecov token is mandatory in the v4 action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,7 +186,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         flags: ckan
-        token: ${{ secrets.CODECOV_TOKEN }
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   test-cdk:
     name: test-cdk
@@ -235,5 +235,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           flags: cdk
-          token: ${{ secrets.CODECOV_TOKEN }
+          token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,6 +186,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         flags: ckan
+        token: ${{ secrets.CODECOV_TOKEN }
 
   test-cdk:
     name: test-cdk
@@ -234,4 +235,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           flags: cdk
+          token: ${{ secrets.CODECOV_TOKEN }
 


### PR DESCRIPTION
https://github.com/marketplace/actions/codecov#breaking-changes

this adds the required token to codecov action.