### PR TITLE
REKDAT-135: Use nodejs 20 runtime in lambda functions

### DIFF
--- a/cdk/lib/lambdas/create-databases-and-users.ts
+++ b/cdk/lib/lambdas/create-databases-and-users.ts
@@ -1,6 +1,6 @@
 import {Construct} from "constructs";
 import {NodejsFunction} from "aws-cdk-lib/aws-lambda-nodejs";
-import {aws_ec2, aws_rds} from "aws-cdk-lib";
+import {aws_ec2, aws_lambda, aws_rds} from "aws-cdk-lib";
 import {CreateDatabasesAndUsersProps} from "./create-databases-and-users-props";
 import {Trigger, TriggerFunction} from "aws-cdk-lib/triggers";
 import {ISecret} from "aws-cdk-lib/aws-secretsmanager";
@@ -33,6 +33,7 @@ export class CreateDatabasesAndUsers extends Construct {
         },
         vpc: props.vpc,
         securityGroups: [secGroup],
+        runtime: aws_lambda.Runtime.NODEJS_20_X,
         bundling: {
           externalModules: [
             "sqlite3",

--- a/cdk/lib/lambdas/send-to-zulip.ts
+++ b/cdk/lib/lambdas/send-to-zulip.ts
@@ -2,6 +2,7 @@ import {Construct} from "constructs";
 import {NodejsFunction} from "aws-cdk-lib/aws-lambda-nodejs";
 import {SendToZulipProps} from "./send-to-zulip-props";
 import * as sm from 'aws-cdk-lib/aws-secretsmanager';
+import {aws_lambda} from "aws-cdk-lib";
 
 export class SendToZulip extends Construct {
   readonly lambda: NodejsFunction;
@@ -18,7 +19,8 @@ export class SendToZulip extends Construct {
         ZULIP_API_URL: props.zulipApiUrl,
         ZULIP_STREAM: props.zulipStream,
         ZULIP_TOPIC: props.zulipTopic
-      }
+      },
+      runtime: aws_lambda.Runtime.NODEJS_20_X,
     });
     zulipSecret.grantRead(this.lambda);
   }


### PR DESCRIPTION
The default runtime in cdk NodejsFunctions was reverted to nodejs 16 in cdk version 2.93.0 and since we updated our cdk from 2.92.0 to the latest, nodejs runtimes were downgraded to version 16. This defines runtime to nodejs 20 explicitly. 