### PR TITLE
Refactor CommonStackProps to EnvStackProps and NetworkStackProps

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -19,6 +19,7 @@ import {FileSystemStack} from "../lib/filesystem-stack";
 import {CkanStack} from "../lib/ckan-stack";
 import {ShieldStack} from "../lib/shield-stack";
 import {MonitoringStack} from '../lib/monitoring-stack';
+import {ParameterStack} from "../lib/parameter-stack";
 
 const app = new cdk.App();
 
@@ -80,6 +81,13 @@ const VpcStackDev = new VpcStack(app, 'VpcStack-dev', {
   }
 })
 
+const ParameterStackDev = new ParameterStack(app, 'ParameterStack-dev', {
+  env: {
+    account: devStackProps.account,
+    region: devStackProps.region
+  },
+  environment: devStackProps.environment,
+})
 
 
 const KmsKeyStackDev = new KmsKeyStack(app, 'KmsKeyStack-dev', {
@@ -87,9 +95,7 @@ const KmsKeyStackDev = new KmsKeyStack(app, 'KmsKeyStack-dev', {
     account: devStackProps.account,
     region: devStackProps.region
   },
-  envProps: envProps,
   environment: devStackProps.environment,
-  vpc: VpcStackDev.vpc,
 })
 
 const BackupStackDev = new BackupStack(app, 'BackupStack-dev', {
@@ -97,8 +103,6 @@ const BackupStackDev = new BackupStack(app, 'BackupStack-dev', {
     account: devStackProps.account,
     region: devStackProps.region,
   },
-  envProps: envProps,
-  vpc: VpcStackDev.vpc,
   environment: devStackProps.environment,
   importVault: false,
   backups: true
@@ -109,7 +113,6 @@ const DatabaseStackDev = new DatabaseStack(app, 'DatabaseStack-dev', {
     account: devStackProps.account,
     region: devStackProps.region
   },
-  envProps: envProps,
   environment: devStackProps.environment,
   vpc: VpcStackDev.vpc,
   multiAz: false,
@@ -125,7 +128,6 @@ const LoadBalancerStackDev = new LoadBalancerStack(app, 'LoadBalancerStack-dev',
     account: devStackProps.account,
     region: devStackProps.region
   },
-  envProps: envProps,
   environment: devStackProps.environment,
   vpc: VpcStackDev.vpc
 })
@@ -135,7 +137,6 @@ const LambdaStackDev = new LambdaStack(app, 'LambdaStack-dev', {
     account: devStackProps.account,
     region: devStackProps.region,
   },
-  envProps: envProps,
   environment: devStackProps.environment,
   ckanInstance: DatabaseStackDev.ckanInstance,
   ckanAdminCredentials: DatabaseStackDev.ckanAdminCredentials,
@@ -165,7 +166,6 @@ const EcsClusterStackDev = new EcsClusterStack(app, 'EcsClusterStack-dev', {
     account: devStackProps.account,
     region: devStackProps.region,
   },
-  envProps: envProps,
   environment: devStackProps.environment,
   vpc: VpcStackDev.vpc
 })
@@ -175,7 +175,6 @@ const FileSystemStackDev = new FileSystemStack(app, 'FilesystemStack-dev', {
     account: devStackProps.account,
     region: devStackProps.region,
   },
-  envProps: envProps,
   environment: devStackProps.environment,
   vpc: VpcStackDev.vpc,
   terminationProtection: true
@@ -263,7 +262,6 @@ const CkanStackDev = new CkanStack(app, 'CkanStack-dev', {
     taskMaxCapacity: 1
   },
   vpc: VpcStackDev.vpc
-
 })
 
 const ShieldStackDev = new ShieldStack(app, 'ShieldStack-dev', {
@@ -271,25 +269,20 @@ const ShieldStackDev = new ShieldStack(app, 'ShieldStack-dev', {
     account: devStackProps.account,
     region: devStackProps.region,
   },
-  envProps: envProps,
   environment: devStackProps.environment,
   loadBalancer: LoadBalancerStackDev.loadBalancer,
   rateLimitRequestSamplingEnabled: false,
   highPriorityRequestSamplingEnabled: false,
   bannedIpsRequestSamplingEnabled: false,
   requestSampleAllTrafficEnabled: false,
-  vpc: VpcStackDev.vpc
 })
 
 const MonitoringStackDev = new MonitoringStack(app, 'MonitoringStack-dev', {
   sendToZulipLambda: LambdaStackDev.sendToZulipLambda,
-  envProps: envProps,
   env: {
     account: devStackProps.account,
     region: devStackProps.region,
   },
-  environment: devStackProps.environment,
-  vpc: VpcStackDev.vpc
 });
 
 // Production
@@ -307,9 +300,7 @@ const KmsKeyStackProd = new KmsKeyStack(app, 'KmsKeyStack-prod', {
     account: prodStackProps.account,
     region: prodStackProps.region
   },
-  envProps: envProps,
-  environment: prodStackProps.environment,
-  vpc: VpcStackProd.vpc,
+  environment: prodStackProps.environment
 })
 
 const BackupStackProd = new BackupStack(app, 'BackupStack-prod', {
@@ -317,8 +308,6 @@ const BackupStackProd = new BackupStack(app, 'BackupStack-prod', {
     account: prodStackProps.account,
     region: prodStackProps.region,
   },
-  envProps: envProps,
-  vpc: VpcStackProd.vpc,
   environment: prodStackProps.environment,
   importVault: false,
   backups: true
@@ -329,7 +318,6 @@ const DatabaseStackProd = new DatabaseStack(app, 'DatabaseStack-prod', {
     account: prodStackProps.account,
     region: prodStackProps.region
   },
-  envProps: envProps,
   environment: prodStackProps.environment,
   vpc: VpcStackProd.vpc,
   multiAz: false,
@@ -345,7 +333,6 @@ const LoadBalancerStackProd = new LoadBalancerStack(app, 'LoadBalancerStack-prod
     account: prodStackProps.account,
     region: prodStackProps.region
   },
-  envProps: envProps,
   environment: prodStackProps.environment,
   vpc: VpcStackProd.vpc
 })
@@ -355,7 +342,6 @@ const LambdaStackProd = new LambdaStack(app, 'LambdaStack-prod', {
     account: prodStackProps.account,
     region: prodStackProps.region,
   },
-  envProps: envProps,
   environment: prodStackProps.environment,
   ckanInstance: DatabaseStackProd.ckanInstance,
   ckanAdminCredentials: DatabaseStackProd.ckanAdminCredentials,
@@ -377,7 +363,6 @@ const EcsClusterStackProd = new EcsClusterStack(app, 'EcsClusterStack-prod', {
     account: prodStackProps.account,
     region: prodStackProps.region,
   },
-  envProps: envProps,
   environment: prodStackProps.environment,
   vpc: VpcStackProd.vpc
 })
@@ -387,7 +372,6 @@ const FileSystemStackProd = new FileSystemStack(app, 'FilesystemStack-prod', {
     account: prodStackProps.account,
     region: prodStackProps.region,
   },
-  envProps: envProps,
   environment: prodStackProps.environment,
   vpc: VpcStackProd.vpc,
   terminationProtection: true
@@ -483,23 +467,19 @@ const ShieldStackProd = new ShieldStack(app, 'ShieldStack-prod', {
     account: prodStackProps.account,
     region: prodStackProps.region,
   },
-  envProps: envProps,
   environment: prodStackProps.environment,
   loadBalancer: LoadBalancerStackProd.loadBalancer,
   rateLimitRequestSamplingEnabled: false,
   highPriorityRequestSamplingEnabled: false,
   bannedIpsRequestSamplingEnabled: false,
-  requestSampleAllTrafficEnabled: false,
-  vpc: VpcStackProd.vpc
+  requestSampleAllTrafficEnabled: false
 })
 
 const MonitoringStackProd = new MonitoringStack(app, 'MonitoringStack-prod', {
   sendToZulipLambda: LambdaStackProd.sendToZulipLambda,
-  envProps: envProps,
   env: {
     account: prodStackProps.account,
     region: prodStackProps.region,
   },
-  environment: prodStackProps.environment,
   vpc: VpcStackProd.vpc
 });

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -19,7 +19,6 @@ import {FileSystemStack} from "../lib/filesystem-stack";
 import {CkanStack} from "../lib/ckan-stack";
 import {ShieldStack} from "../lib/shield-stack";
 import {MonitoringStack} from '../lib/monitoring-stack';
-import {ParameterStack} from "../lib/parameter-stack";
 
 const app = new cdk.App();
 
@@ -79,14 +78,6 @@ const VpcStackDev = new VpcStack(app, 'VpcStack-dev', {
     account: devStackProps.account,
     region: devStackProps.region
   }
-})
-
-const ParameterStackDev = new ParameterStack(app, 'ParameterStack-dev', {
-  env: {
-    account: devStackProps.account,
-    region: devStackProps.region
-  },
-  environment: devStackProps.environment,
 })
 
 
@@ -480,6 +471,5 @@ const MonitoringStackProd = new MonitoringStack(app, 'MonitoringStack-prod', {
   env: {
     account: prodStackProps.account,
     region: prodStackProps.region,
-  },
-  vpc: VpcStackProd.vpc
+  }
 });

--- a/cdk/lib/backup-stack-props.ts
+++ b/cdk/lib/backup-stack-props.ts
@@ -1,6 +1,6 @@
-import {CommonStackProps} from "./common-stack-props";
+import {EnvStackProps} from "./env-stack-props";
 
-export interface BackupStackProps extends CommonStackProps {
+export interface BackupStackProps extends EnvStackProps {
     importVault: boolean;
     backups: boolean;
 }

--- a/cdk/lib/common-stack-props.ts
+++ b/cdk/lib/common-stack-props.ts
@@ -1,9 +1,6 @@
-import {StackProps} from "aws-cdk-lib";
-import {IVpc} from "aws-cdk-lib/aws-ec2";
 import {EnvProps} from "./env-props";
+import {NetworkStackProps} from "./network-stack-props";
 
-export interface CommonStackProps extends StackProps {
+export interface CommonStackProps extends NetworkStackProps {
   envProps: EnvProps;
-  environment: string;
-  vpc: IVpc;
 }

--- a/cdk/lib/database-stack-props.ts
+++ b/cdk/lib/database-stack-props.ts
@@ -1,7 +1,7 @@
-import {CommonStackProps} from "./common-stack-props";
-import {aws_backup} from "aws-cdk-lib";
+import {aws_backup, aws_ec2} from "aws-cdk-lib";
+import {NetworkStackProps} from "./network-stack-props";
 
-export interface DatabaseStackProps extends CommonStackProps {
+export interface DatabaseStackProps extends NetworkStackProps {
     multiAz: boolean;
     backups: boolean;
     backupPlan: aws_backup.BackupPlan;

--- a/cdk/lib/ecs-cluster-stack.ts
+++ b/cdk/lib/ecs-cluster-stack.ts
@@ -1,11 +1,11 @@
 import {aws_ecs, aws_servicediscovery, Stack} from "aws-cdk-lib";
 import {Construct} from "constructs";
-import {CommonStackProps} from "./common-stack-props";
+import {NetworkStackProps} from "./network-stack-props";
 
 export class EcsClusterStack extends Stack {
   readonly cluster: aws_ecs.ICluster;
   readonly namespace: aws_servicediscovery.INamespace;
-  constructor(scope: Construct, id: string, props: CommonStackProps) {
+  constructor(scope: Construct, id: string, props: NetworkStackProps) {
     super(scope, id, props);
 
     this.cluster = new aws_ecs.Cluster(this, 'ECSCluster', {

--- a/cdk/lib/efs-stack-props.ts
+++ b/cdk/lib/efs-stack-props.ts
@@ -1,9 +1,7 @@
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 
-import { CommonStackProps } from './common-stack-props';
-import {aws_backup} from "aws-cdk-lib";
+import {NetworkStackProps} from "./network-stack-props";
 
-export interface EfsStackProps extends CommonStackProps {
-  vpc: ec2.IVpc;
+export interface EfsStackProps extends NetworkStackProps {
   terminationProtection: boolean;
 }

--- a/cdk/lib/env-stack-props.ts
+++ b/cdk/lib/env-stack-props.ts
@@ -1,0 +1,6 @@
+import {StackProps} from "aws-cdk-lib";
+import {EnvProps} from "./env-props";
+
+export interface EnvStackProps extends StackProps {
+  environment: string;
+}

--- a/cdk/lib/kms-key-stack.ts
+++ b/cdk/lib/kms-key-stack.ts
@@ -1,11 +1,11 @@
 import {aws_kms, Stack, StackProps} from "aws-cdk-lib";
 import {Construct} from "constructs";
-import {CommonStackProps} from "./common-stack-props";
+import {EnvStackProps} from "./env-stack-props";
 
 export class KmsKeyStack extends Stack {
     readonly databaseEncryptionKey: aws_kms.IKey;
-  
-    constructor(scope: Construct, id: string, props: CommonStackProps) {
+
+    constructor(scope: Construct, id: string, props: EnvStackProps) {
         super(scope, id, props);
 
         this.databaseEncryptionKey = new aws_kms.Key(this, 'databaseEncryptionKey', {

--- a/cdk/lib/lambda-stack-props.ts
+++ b/cdk/lib/lambda-stack-props.ts
@@ -1,7 +1,7 @@
 import {aws_rds, aws_kms, StackProps} from "aws-cdk-lib";
-import {CommonStackProps} from "./common-stack-props";
+import {NetworkStackProps} from "./network-stack-props";
 
-export interface LambdaStackProps extends CommonStackProps {
+export interface LambdaStackProps extends NetworkStackProps {
   ckanInstance: aws_rds.IDatabaseInstance;
   ckanAdminCredentials: aws_rds.Credentials;
 }

--- a/cdk/lib/lambda-stack.ts
+++ b/cdk/lib/lambda-stack.ts
@@ -20,7 +20,6 @@ export class LambdaStack extends Stack {
 
     const createDatabases = new CreateDatabasesAndUsers(this, 'create-databases-and-users', {
       env: props.env,
-      envProps: props.envProps,
       ckanInstance: props.ckanInstance,
       ckanAdminCredentials: props.ckanAdminCredentials,
       vpc: props.vpc,
@@ -35,10 +34,8 @@ export class LambdaStack extends Stack {
       zulipApiUrl: 'turina.dvv.fi',
       zulipStream: 'DGA',
       zulipTopic: 'Container restarts',
-      envProps: props.envProps,
       env: props.env,
-      environment: props.environment,
-      vpc: props.vpc
+      environment: props.environment
     });
     this.sendToZulipLambda = sendToZulip.lambda;
   }

--- a/cdk/lib/lambdas/create-databases-and-users-props.ts
+++ b/cdk/lib/lambdas/create-databases-and-users-props.ts
@@ -1,7 +1,8 @@
 import {aws_kms, aws_rds, StackProps} from "aws-cdk-lib";
-import {CommonStackProps} from "../common-stack-props";
 
-export interface CreateDatabasesAndUsersProps extends CommonStackProps{
+import {NetworkStackProps} from "../network-stack-props";
+
+export interface CreateDatabasesAndUsersProps extends NetworkStackProps {
   ckanInstance: aws_rds.IDatabaseInstance,
   ckanAdminCredentials: aws_rds.Credentials,
   secretsEncryptionKey: aws_kms.IKey;

--- a/cdk/lib/lambdas/send-to-zulip-props.ts
+++ b/cdk/lib/lambdas/send-to-zulip-props.ts
@@ -1,6 +1,6 @@
-import {CommonStackProps} from "../common-stack-props";
+import {EnvStackProps} from "../env-stack-props";
 
-export interface SendToZulipProps extends CommonStackProps {
+export interface SendToZulipProps extends EnvStackProps {
   zulipApiUser: string,
   zulipApiUrl: string,
   zulipStream: string,

--- a/cdk/lib/load-balancer-stack.ts
+++ b/cdk/lib/load-balancer-stack.ts
@@ -1,12 +1,12 @@
 import {aws_ec2, aws_s3, Duration, Stack} from "aws-cdk-lib";
 import {Construct} from "constructs";
 import {ApplicationLoadBalancer, ApplicationProtocol} from "aws-cdk-lib/aws-elasticloadbalancingv2";
-import {CommonStackProps} from "./common-stack-props";
 import {BucketEncryption} from "aws-cdk-lib/aws-s3";
+import {NetworkStackProps} from "./network-stack-props";
 
 export class LoadBalancerStack extends Stack {
   readonly loadBalancer: ApplicationLoadBalancer
-  constructor(scope: Construct, id: string, props: CommonStackProps) {
+  constructor(scope: Construct, id: string, props: NetworkStackProps) {
     super(scope, id, props);
 
     const secGroup = new aws_ec2.SecurityGroup(this, 'loadBalancerSecurityGroup', {

--- a/cdk/lib/monitoring-stack-props.ts
+++ b/cdk/lib/monitoring-stack-props.ts
@@ -1,7 +1,7 @@
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
-import { CommonStackProps } from './common-stack-props';
+import {StackProps} from "aws-cdk-lib";
 
-export interface MonitoringStackProps extends CommonStackProps {
+export interface MonitoringStackProps extends StackProps {
   sendToZulipLambda: NodejsFunction
 }
 

--- a/cdk/lib/network-stack-props.ts
+++ b/cdk/lib/network-stack-props.ts
@@ -1,0 +1,6 @@
+import {EnvStackProps} from "./env-stack-props";
+import {aws_ec2} from "aws-cdk-lib";
+
+export interface NetworkStackProps extends EnvStackProps {
+  vpc: aws_ec2.IVpc;
+}

--- a/cdk/lib/shield-stack-props.ts
+++ b/cdk/lib/shield-stack-props.ts
@@ -1,7 +1,8 @@
 import {aws_elasticloadbalancingv2} from "aws-cdk-lib";
-import {CommonStackProps} from "./common-stack-props";
 
-export interface ShieldStackProps extends CommonStackProps{
+import {EnvStackProps} from "./env-stack-props";
+
+export interface ShieldStackProps extends EnvStackProps {
   loadBalancer: aws_elasticloadbalancingv2.IApplicationLoadBalancer,
   bannedIpsRequestSamplingEnabled: boolean,
   requestSampleAllTrafficEnabled: boolean,


### PR DESCRIPTION
Refactors CommonStackProps to smaller interfaces.

```mermaid
---
title: StackProps
---
classDiagram
  StackProps <|-- EnvStackProps
  EnvStackProps <|-- NetworkStackProps
  NetworkStackProps <|-- CommonStackProps 

class StackProps{
  object env
}

class EnvStackProps{
  string environment
}

class NetworkStackProps{
  ec2.IVpc vpc
}

class CommonStackProps{
  EnvProps envProps
}

```