### PR TITLE
REKDAT-68: Fix typo in secret name

### DIFF
--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -181,7 +181,7 @@ export class CkanStack extends Stack {
     if ( props.analyticsEnabled ) {
 
       const matomoSecret = aws_secretsmanager.Secret.fromSecretNameV2(this, 'matomoSecret',
-        `${props.environment}/matomo`)
+        `/${props.environment}/matomo`)
 
       ckanContainerSecrets['MATOMO_TOKEN'] = aws_ecs.Secret.fromSecretsManager(matomoSecret)
     }


### PR DESCRIPTION
Secrets aren't named without preceding slash character. 