### PR TITLE
REKDAT-91: Add admin-configurable global info messages and service alerts

### DIFF
--- a/assets/src/scss/alert.scss
+++ b/assets/src/scss/alert.scss
@@ -1,0 +1,65 @@
+@use "variables" as rd;
+
+.alert {
+  display: flex;
+  gap: 20px;
+  align-items: center;
+  color: rd.$color-black;
+  font-size: rd.$font-size-sm;
+  font-weight: rd.$font-weight-normal;
+  letter-spacing: 0px;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  line-height: 1.5;
+  width: 100%;
+  padding: 0 15px 0 15px;
+  border: none;
+  border-radius: 0;
+  margin: 0;
+  flex-grow: 1;
+
+  &.alert-error {
+    color: rd.$color-white;
+    background: rd.$color-alert-error;
+    border-bottom: 1px solid rd.$color-alert-info-shade;
+  }
+  &.alert-warning {
+    background: rd.$color-alert-warning;
+  }
+  &.alert-info {
+    background: rd.$color-alert-info;
+    border-bottom: 1px solid rd.$color-alert-info-shade;
+  }
+
+  i {
+    font-size: 24px;
+  }
+
+  .message {
+    margin: 15px 0 15px 0;
+    flex-grow: 1;
+  }
+  .btn-close {
+    display: flex;
+    gap: 5px;
+    align-items: center;
+    position: static;
+    opacity: 1.0;
+    color: inherit;
+    background: none;
+    width: auto;
+    height: auto;
+    padding: 7px;
+    border: 1px solid transparent;
+    border-radius: 0;
+
+    &:hover {
+      border-color: rd.$color-black;
+    }
+    i {
+      font-size: 14px;
+    }
+
+  }
+}

--- a/assets/src/scss/ckan/main.scss
+++ b/assets/src/scss/ckan/main.scss
@@ -7,6 +7,7 @@
 @use "../base";
 @use "../input";
 @use "../ckeditor";
+@use "../alert";
 
 @use "common";
 @use "header";

--- a/assets/src/scss/variables.scss
+++ b/assets/src/scss/variables.scss
@@ -30,6 +30,10 @@ $color-badge-text: tokens.$fi-color-black-light1; // #949494
 $color-danger: tokens.$fi-color-alert-base; // #c33932
 $color-success: tokens.$fi-color-success-base; // 09A580
 $color-input-border: tokens.$fi-color-black-light1; // #949494
+$color-alert-info: tokens.$fi-color-info-light1; // #ebf3ff
+$color-alert-info-shade: #1770ee33; // not found in tokens
+$color-alert-warning: tokens.$fi-color-warning-base; // #f6af09
+$color-alert-error: tokens.$fi-color-alert-base; // #ae332c
 
 // Text
 $font-size-lg: 22px;

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/i18n/ckanext-restricteddata.pot
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/i18n/ckanext-restricteddata.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-restricteddata 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-04-22 10:29+0000\n"
+"POT-Creation-Date: 2024-05-14 09:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,18 +18,18 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.10.3\n"
 
-#: ckanext/restricteddata/plugin.py:151
+#: ckanext/restricteddata/plugin.py:162
 #: ckanext/restricteddata/templates/header.html:99
 #: ckanext/restricteddata/templates/home/layout1.html:52
 #: ckanext/restricteddata/templates/package/search.html:11
 msgid "Datasets"
 msgstr ""
 
-#: ckanext/restricteddata/plugin.py:152
+#: ckanext/restricteddata/plugin.py:163
 msgid "Tags"
 msgstr ""
 
-#: ckanext/restricteddata/plugin.py:153
+#: ckanext/restricteddata/plugin.py:164
 msgid "Format"
 msgstr ""
 
@@ -628,6 +628,7 @@ msgstr ""
 msgid "View Organization"
 msgstr ""
 
+#: ckanext/restricteddata/templates/user/dashboard.html:4
 #: ckanext/restricteddata/translations.py:159
 msgid "News feed"
 msgstr ""
@@ -636,6 +637,7 @@ msgstr ""
 msgid "Activity from items that I'm following"
 msgstr ""
 
+#: ckanext/restricteddata/templates/user/dashboard.html:5
 #: ckanext/restricteddata/translations.py:161
 msgid "My Datasets"
 msgstr ""
@@ -644,6 +646,7 @@ msgstr ""
 msgid "Add Dataset"
 msgstr ""
 
+#: ckanext/restricteddata/templates/user/dashboard.html:6
 #: ckanext/restricteddata/translations.py:163
 msgid "My Organizations"
 msgstr ""
@@ -971,8 +974,16 @@ msgstr ""
 msgid "Skip to main content"
 msgstr ""
 
-#: ckanext/restricteddata/templates/page.html:34
+#: ckanext/restricteddata/templates/page.html:38
 msgid "Breadcrumb"
+msgstr ""
+
+#: ckanext/restricteddata/templates/admin/config.html:9
+msgid "Info message"
+msgstr ""
+
+#: ckanext/restricteddata/templates/admin/config.html:19
+msgid "Service alert"
 msgstr ""
 
 #: ckanext/restricteddata/templates/home/layout1.html:3
@@ -1087,6 +1098,11 @@ msgstr ""
 #: ckanext/restricteddata/templates/organization/read.html:14
 #: ckanext/restricteddata/templates/package/search.html:51
 msgid "Filter search"
+msgstr ""
+
+#: ckanext/restricteddata/templates/organization/read.html:22
+#: ckanext/restricteddata/templates/user/read.html:5
+msgid "Manage"
 msgstr ""
 
 #: ckanext/restricteddata/templates/organization/snippets/helper.html:15

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
@@ -39,6 +39,17 @@ class RestrictedDataPlugin(plugins.SingletonPlugin, DefaultTranslation):
         toolkit.add_public_directory(config_, "public")
         toolkit.add_resource("assets", "restricteddata")
 
+    def update_config_schema(self, schema):
+        ignore_missing = toolkit.get_validator('ignore_missing')
+        unicode_safe = toolkit.get_validator('unicode_safe')
+
+        schema.update({
+            f'ckanext.restricteddata.{field}_{lang}': [ignore_missing, unicode_safe]
+            for field in ['info_message', 'service_alert']
+            for lang in ['fi', 'sv', 'en']})
+
+        return schema
+
     # ITemplateHelpers
 
     def get_helpers(self):

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/admin/config.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/admin/config.html
@@ -1,0 +1,40 @@
+{% ckan_extends %}
+
+{% import 'macros/form.html' as form %}
+
+{% block admin_form %}
+
+  {{ super() }}
+
+  <h3>{{ _('Info message') }}</h3>
+
+  {% for lang in ['fi', 'sv', 'en'] %}
+    {{ form.input('ckanext.restricteddata.info_message_%s' % lang,
+                  id='field-ckanext.restricteddata.info_message_%s' % lang,
+                  label=_('Info message (%s)' % lang),
+                  value=data['ckanext.restricteddata.info_message_%s' % lang],
+                  error=errors['ckanext.restricteddata.info_message_%s' % lang]) }}
+  {% endfor %}
+
+  <h3>{{ _('Service alert') }}</h3>
+
+  {% for lang in ['fi', 'sv', 'en'] %}
+    {{ form.input('ckanext.restricteddata.service_alert_%s' % lang,
+                  id='field-ckanext.restricteddata.service_alert_%s' % lang,
+                  label=_('Service alert (%s)' % lang),
+                  value=data['ckanext.restricteddata.service_alert_%s' % lang],
+                  error=errors['ckanext.restricteddata.service_alert_%s' % lang]) }}
+  {% endfor %}
+
+{% endblock %}
+
+
+{% block admin_form_help %}
+
+  {{ super() }}
+
+  <p><strong>Info message:</strong> Message shown in a notification on every page.</p>
+
+  <p><strong>Service alert:</strong> Maintenance message shown in a notification on every page.</p>
+
+{% endblock %}

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/page.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/page.html
@@ -8,6 +8,10 @@
     </div>
   {% endblock %}
 
+  {% block global_messages %}
+    {% snippet 'snippets/global_messages.html' %}
+  {% endblock %}
+
   {#
   Override the header on a page by page basis by extending this block. If
   making sitewide header changes it is preferable to override the header.html
@@ -31,7 +35,7 @@
           {% endblock %}
 
           {% block toolbar %}
-            <div class="toolbar" role="navigation" aria-label="{{ _("Breadcrumb") }}">
+            <div class="toolbar" role="navigation" aria-label="{{ _('Breadcrumb') }}">
               {% block breadcrumb %}
                 {% if self.breadcrumb_content() | trim %}
                   <ol class="breadcrumb">

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/snippets/alert.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/snippets/alert.html
@@ -1,0 +1,19 @@
+{% if type == "warning" %}
+  {% set icon = "fa-regular fa-triangle-exclamation" %}
+  {% set alert_class = "alert-warning" %}
+{% elif type == "error" %}
+  {% set icon = "fa-regular fa-circle-exclamation" %}
+  {% set alert_class = "alert-error" %}
+{% else %}
+  {% set icon = "fa-regular fa-circle-info" %}
+  {% set alert_class = "alert-info" %}
+{% endif %}
+
+<div class="alert {{ alert_class }} alert-dismissible show" role="alert">
+  <i class="fa {{ icon }}"></i>
+  <span class="message">{{ message }}</span>
+  <button type="button" class="btn-close close" data-bs-dismiss="alert" aria-label="Close">
+    Close
+    <i class="fa fa-light fa-xmark"></i>
+  </button>
+</div>

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/snippets/global_messages.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/snippets/global_messages.html
@@ -1,0 +1,12 @@
+{% set current_lang = h.get_lang_prefix() %}
+
+{% set service_alert = c['ckanext.restricteddata.service_alert_%s' % current_lang] %}
+{% if service_alert %}
+  {% snippet 'snippets/alert.html', type="error", message=service_alert %}
+{% endif %}
+
+{% set info_message = c['ckanext.restricteddata.info_message_%s' % current_lang] %}
+{% if info_message %}
+  {% snippet 'snippets/alert.html', type="info", message=info_message %}
+{% endif %}
+

--- a/ckan/templates/ckan.ini.j2
+++ b/ckan/templates/ckan.ini.j2
@@ -133,7 +133,12 @@ ckanext.restricteddata.news.endpoint_url = https://palveluhallinta.suomi.fi/api/
 ckanext.restricteddata.news.ssl_verify = True
 ckanext.restricteddata.news.tags = uutinen,haeirioetiedote
 ckanext.restricteddata.news.url_template = https://palveluhallinta.suomi.fi/{language}/ajankohtaista/uutiset/{id}
-
+ckanext.restricteddata.info_message_fi = 
+ckanext.restricteddata.info_message_sv = 
+ckanext.restricteddata.info_message_en = 
+ckanext.restricteddata.service_alert_fi = 
+ckanext.restricteddata.service_alert_sv = 
+ckanext.restricteddata.service_alert_en = 
 
 [loggers]
 keys = root, ckan, ckanext


### PR DESCRIPTION
- Added multilingual info messages and service alerts to ckan config schema
- Added text fields to modify the messages from ckan-admin/config
- Added alert-snippet to create dismissable alerts in suomi.fi style
- Added global_messages-snippet to show info messages and service alerts in base layout

![image](https://github.com/vrk-kpa/restricteddata/assets/726461/ffd2fb35-e60d-4ad8-a100-5d99278f7777)
