### PR TITLE
REKDAT-68: init matomo tables

### DIFF
--- a/ckan/scripts/init_ckan.sh
+++ b/ckan/scripts/init_ckan.sh
@@ -26,7 +26,7 @@ fi
 # init ckan extension databases
 echo "init ckan extension databases ..."
 ckan -c ${APP_DIR}/ckan.ini harvester initdb
-ckan -c ${APP_DIR}/ckan.ini db upgrade -p matomo
+ckan -c ${APP_DIR}/ckan.ini matomo init_db && ckan -c ${APP_DIR}/ckan.ini db upgrade -p matomo
 
 echo "Create default restricteddata categories ..."
 ckan -c ${APP_DIR}/ckan.ini restricteddata create-default-categories


### PR DESCRIPTION
Alembic migrations do not create the initial state of database, so the old init command needs to be run.