### PR TITLE
REKDAT-157: Fix solr fs mounts

### DIFF
--- a/cdk/lib/solr-stack.ts
+++ b/cdk/lib/solr-stack.ts
@@ -70,7 +70,7 @@ export class SolrStack extends Stack {
     });
 
     solrContainer.addMountPoints({
-      containerPath: '/opt/solr/server/solr/ckan/data',
+      containerPath: '/var/solr/data/ckan/data',
       readOnly: false,
       sourceVolume: 'solr_data',
     });

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     networks:
       - backend
     volumes:
-      - solr_data:/opt/solr/server/solr/ckan/data
+      - solr_data:/var/solr/data/ckan/data
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s http://localhost:8983/solr/ckan/admin/ping?wt=json | grep -o 'OK'"]
       interval: 15s


### PR DESCRIPTION
The same fix as in https://github.com/vrk-kpa/opendata/pull/2225 and https://github.com/vrk-kpa/opendata/pull/2227, the solr index should be on efs disk mount instead on the container.