### PR TITLE
REKDAT-127: Add preliminary support for PAHA authentication

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -188,8 +188,7 @@ jobs:
         pip install -r requirements.txt
         pip install -e .
     - name: Run tests
-      run: |
-        pytest --ckan-ini=ckan/ckanext/ckanext-restricteddata/test.ini --cov=ckanext.restricteddata --disable-warnings ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests
+      run: pytest --ckan-ini=ckan/ckanext/ckanext-restricteddata/test.ini --cov=ckanext.restricteddata --disable-warnings ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
       with:

--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -101,6 +101,7 @@ export class CkanStack extends Stack {
       CKAN_PROFILING_ENABLED: 'false',
       CKAN_LOG_LEVEL: 'INFO',
       CKAN_EXT_LOG_LEVEL: 'INFO',
+      CKAN_PAHA_JWT_ALGORITHM: 'RS256',
 
       // .env
       CKAN_IMAGE_TAG: props.envProps.CKAN_IMAGE_TAG,
@@ -173,12 +174,16 @@ export class CkanStack extends Stack {
       }
     })
 
+    const pahaJwtKeySecret = aws_secretsmanager.Secret.fromSecretNameV2(this, 'pahaJwtKeySecret',
+      `/${props.environment}/paha_jwt_key`)
+
 
     const ckanContainerSecrets: { [key: string]: aws_ecs.Secret; } = {
       // .env.ckan
       CKAN_BEAKER_SESSION_SECRET: aws_ecs.Secret.fromSecretsManager(beakerSecret),
       CKAN_APP_INSTANCE_UUID: aws_ecs.Secret.fromSecretsManager(appUUIDSecret),
       CKAN_BEAKER_SESSION_VALIDATE_KEY: aws_ecs.Secret.fromSecretsManager(beakerValidateKeySecret),
+      CKAN_PAHA_JWT_KEY: aws_ecs.Secret.fromSecretsManager(pahaJwtKeySecret),
       // .env
       DB_CKAN_PASS: aws_ecs.Secret.fromSecretsManager(props.ckanInstanceCredentials.secret!, 'password'),
       SMTP_USERNAME: aws_ecs.Secret.fromSecretsManager(smtpSecrets, 'username'),

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/assets/css/restricteddata.css
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/assets/css/restricteddata.css
@@ -1,0 +1,1 @@
+/* Placeholder for site styles */

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
@@ -5,7 +5,6 @@ import json
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 from ckan.logic import NotFound
-from ckan.common import g
 from ckanext.pages.interfaces import IPagesSchema
 from ckan.lib.plugins import DefaultTranslation
 import ckan.model as model
@@ -324,7 +323,6 @@ class RestrictedDataPahaAuthenticationPlugin(plugins.SingletonPlugin):
         
     def create_or_authenticate_paha_user(self, token):
         '''Identifies a user based on a PAHA JWT token creating a new user if needed'''
-        log.info(token)
         user_email = token['email']
         user = model.User.by_email(user_email)
 
@@ -354,8 +352,8 @@ class RestrictedDataPahaAuthenticationPlugin(plugins.SingletonPlugin):
             user = model.User.by_email(user_email)
 
         if user:
-            g.user = user.name
-            g.userobj = user
+            toolkit.g.user = user.name
+            toolkit.g.userobj = user
             login_user(user)
         else:
             raise RuntimeError("Could not find or create PAHA user!")

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
@@ -347,13 +347,20 @@ def test_non_maintainer_can_not_add_dataset_to_group(app):
 
 @pytest.mark.usefixtures("clean_db", "with_plugins", "with_request_context")
 def test_paha_authentication_creates_new_user(app):
-    payload = {"iss": "PAHA", "email": "foo@example.com", "firstName": "foo", "lastName": "bar"}
+    # Get new user profile with PAHA authentication
+    email = "foo@example.com"
+    payload = {"iss": "PAHA", "email": email, "firstName": "foo", "lastName": "bar"}
     key = toolkit.config['ckanext.restricteddata.paha_jwt_key']
     algorithm = toolkit.config['ckanext.restricteddata.paha_jwt_algorithm']
     token = jwt.encode(payload, key, algorithm=algorithm)
     headers = {"Authorization": f'Bearer {token}'}
     response = app.get(url=toolkit.url_for("user.read", id="foo_bar"), headers=headers)
     assert response.status_code == 200
+
+    # Make sure 
+    assert email in response.body
+
+    # Verify that the user has been created 
     user = call_action('user_show', id="foo_bar", context={"ignore_auth": True})
     assert user['fullname'] == "foo bar"
 

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
@@ -48,6 +48,7 @@ To temporary patch the CKAN configuration for the duration of a test you can use
         pass
 """
 import pytest
+import jwt
 
 # import ckanext.restricteddata.plugin as plugin
 from ckan.plugins import plugin_loaded, toolkit
@@ -342,3 +343,40 @@ def test_non_maintainer_can_not_add_dataset_to_group(app):
             call_action('member_create', id=g['id'], object=d['id'],
                         object_type='package', capacity='parent',
                         context={'user': some_user['name'], 'ignore_auth': False})
+
+
+@pytest.mark.usefixtures("clean_db", "with_plugins", "with_request_context")
+def test_paha_authentication_creates_new_user(app):
+    payload = {"iss": "PAHA", "email": "foo@example.com", "firstName": "foo", "lastName": "bar"}
+    key = toolkit.config['ckanext.restricteddata.paha_jwt_key']
+    algorithm = toolkit.config['ckanext.restricteddata.paha_jwt_algorithm']
+    token = jwt.encode(payload, key, algorithm=algorithm)
+    headers = {"Authorization": f'Bearer {token}'}
+    response = app.get(url=toolkit.url_for("user.read", id="foo_bar"), headers=headers)
+    assert response.status_code == 200
+    user = call_action('user_show', id="foo_bar", context={"ignore_auth": True})
+    assert user['fullname'] == "foo bar"
+
+
+@pytest.mark.usefixtures("clean_db", "with_plugins", "with_request_context")
+def test_paha_authentication_logs_in_user(app):
+    some_user = User()
+
+    # Prepare a client that can hold cookies
+    client = app.test_client(use_cookies=True)
+
+    # Get user profile with PAHA authentication
+    payload = {"iss": "PAHA", "email": some_user['email']}
+    key = toolkit.config['ckanext.restricteddata.paha_jwt_key']
+    algorithm = toolkit.config['ckanext.restricteddata.paha_jwt_algorithm']
+    token = jwt.encode(payload, key, algorithm=algorithm)
+    headers = {"Authorization": f'Bearer {token}'}
+    response = client.get(toolkit.url_for("user.read", id=some_user['name']), headers=headers)
+    assert response.status_code == 200
+    # User is logged in if their email is on their profile page
+    assert some_user['email'] in response.body
+
+    # Use the cookies set in previous step to repeat the query
+    response = client.get(toolkit.url_for("user.read", id=some_user['name']))
+    assert response.status_code == 200
+    assert some_user['email'] in response.body

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
@@ -349,7 +349,7 @@ def test_non_maintainer_can_not_add_dataset_to_group(app):
 def test_paha_authentication_creates_new_user(app):
     # Get new user profile with PAHA authentication
     email = "foo@example.com"
-    payload = {"iss": "PAHA", "email": email, "firstName": "foo", "lastName": "bar"}
+    payload = {"iss": "PAHA", "id": "test-id", "email": email, "firstName": "foo", "lastName": "bar"}
     key = toolkit.config['ckanext.restricteddata.paha_jwt_key']
     algorithm = toolkit.config['ckanext.restricteddata.paha_jwt_algorithm']
     token = jwt.encode(payload, key, algorithm=algorithm)
@@ -367,13 +367,14 @@ def test_paha_authentication_creates_new_user(app):
 
 @pytest.mark.usefixtures("clean_db", "with_plugins", "with_request_context")
 def test_paha_authentication_logs_in_user(app):
-    some_user = User()
+    test_id = "test-id"
+    some_user = User(id=test_id)
 
     # Prepare a client that can hold cookies
     client = app.test_client(use_cookies=True)
 
     # Get user profile with PAHA authentication
-    payload = {"iss": "PAHA", "email": some_user['email']}
+    payload = {"iss": "PAHA", "id": test_id}
     key = toolkit.config['ckanext.restricteddata.paha_jwt_key']
     algorithm = toolkit.config['ckanext.restricteddata.paha_jwt_algorithm']
     token = jwt.encode(payload, key, algorithm=algorithm)

--- a/ckan/ckanext/ckanext-restricteddata/setup.cfg
+++ b/ckan/ckanext/ckanext-restricteddata/setup.cfg
@@ -28,6 +28,7 @@ ckan.plugins =
              restricteddata = ckanext.restricteddata.plugin:RestrictedDataPlugin
              restricteddata_pages = ckanext.restricteddata.plugin:RestrictedDataPagesPlugin
              restricteddata_reset = ckanext.restricteddata.plugin:RestrictedDataResetPlugin
+             restricteddata_paha_authentication = ckanext.restricteddata.plugin:RestrictedDataPahaAuthenticationPlugin
 ckan.rdf.profiles =
              restricteddata_dcat_ap = ckanext.restricteddata.dcat:RestrictedDataDCATAPProfile
 

--- a/ckan/ckanext/ckanext-restricteddata/test.ini
+++ b/ckan/ckanext/ckanext-restricteddata/test.ini
@@ -8,7 +8,7 @@ use = config:../ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here. These will override the one defined in CKAN core's test-core.ini
-ckan.plugins = scheming_datasets fluent restricteddata restricteddata_pages pages markdown_editor dcat
+ckan.plugins = scheming_datasets fluent restricteddata_pages pages restricteddata markdown_editor dcat restricteddata_paha_authentication
 
 scheming.dataset_schemas = ckanext.restricteddata.schemas:dataset.json
 scheming.presets = ckanext.scheming:presets.json
@@ -16,6 +16,8 @@ scheming.presets = ckanext.scheming:presets.json
 				   ckanext.restricteddata:presets.json
                    ckanext.markdown_editor:presets.json
 ckanext.dcat.rdf.profiles = restricteddata_dcat_ap
+ckanext.restricteddata.paha_jwt_key = secret
+ckanext.restricteddata.paha_jwt_algorithm = HS256
 
 # Logging configuration
 [loggers]

--- a/ckan/templates/ckan.ini.j2
+++ b/ckan/templates/ckan.ini.j2
@@ -139,6 +139,8 @@ ckanext.restricteddata.info_message_en =
 ckanext.restricteddata.service_alert_fi =
 ckanext.restricteddata.service_alert_sv =
 ckanext.restricteddata.service_alert_en =
+ckanext.restricteddata.paha_jwt_key = {{ environ('CKAN_PAHA_JWT_KEY') }}
+ckanext.restricteddata.paha_jwt_algorithm = {{ environ('CKAN_PAHA_JWT_ALGORITHM') }}
 
 {% if environ('SENTRY_DSN') %}
 sentry.dsn = {{ environ('SENTRY_DSN') }}

--- a/docker/.env.ckan.local
+++ b/docker/.env.ckan.local
@@ -7,7 +7,7 @@ CKAN_BEAKER_SESSION_VALIDATE_KEY="iPBD4P87SdAXPaDERKXhgtiX4P7xhh"
 CKAN_APP_INSTANCE_UUID="{dc6259b8-f112-4d23-8816-aadcede1895c}"
 CKAN_SITE_ID=default
 CKAN_PLUGINS_DEFAULT="fluent scheming_datasets scheming_groups scheming_organizations"
-CKAN_PLUGINS="dcat restricteddata_pages pages restricteddata markdown_editor activity image_view text_view harvest restricteddata_reset"
+CKAN_PLUGINS="dcat restricteddata_pages pages restricteddata markdown_editor activity image_view text_view harvest restricteddata_reset restricteddata_paha_authentication"
 CKAN_PLUGINS_MATOMO="matomo"
 CKAN_WEBASSETS_PATH=/srv/app/data/webassets
 CKAN_MAX_RESOURCE_SIZE=5000
@@ -15,3 +15,6 @@ CKAN_SHOW_POSTIT_DEMO=true
 CKAN_PROFILING_ENABLED=false
 CKAN_LOG_LEVEL=INFO
 CKAN_EXT_LOG_LEVEL=DEBUG
+
+CKAN_PAHA_JWT_KEY=secret
+CKAN_PAHA_JWT_ALGORITHM=HS256


### PR DESCRIPTION
Support for creating users and logging them in using PAHA JWT tokens

- Added configuration for PAHA's JWT key and algorithm. Tests and development environment use symmetric HS256 encryption with a dummy key for simplicity, while AWS environments use RS256 with a separately provided decode key
- `RestrictedDataPahaAuthenticationPlugin` uses a defensive process to determine if the provided bearer token is from PAHA by validating the cryptographic signature. If the identification fails at any point the authentication flow falls back to regular CKAN auth. If the token is valid, the user is identified based on e-mail address and created if it does not exist.
- Added tests for both user creation and logging in with an existing user
