### PR TITLE
REKDAT-163: fix codecov upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,10 +181,16 @@ jobs:
         pip install -e .
     - name: Run tests
       run: pytest --ckan-ini=ckan/ckanext/ckanext-restricteddata/test.ini --cov=ckanext.restricteddata --disable-warnings ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests
+
+    - name: install codecov requirements
+      run: |
+        apk add gpg gpg-agent
+
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
       with:
         flags: ckan
+        os: alpine
         token: ${{ secrets.CODECOV_TOKEN }}
 
   test-e2e:

--- a/ckan/README.md
+++ b/ckan/README.md
@@ -1,4 +1,4 @@
-# Restricted data CKAN container
+# Restricted data CKAN container 
 
 ## Developer notes
 


### PR DESCRIPTION
While running ckan alpine container, codecov@v4 requires gpg and gpg-agent. Additionally v4 doesn't identify alpine correctly.