### PR TITLE
REKDAT-151: Add highvalue categories to UI

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/helpers.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/helpers.py
@@ -216,3 +216,19 @@ def get_assignable_groups_for_package(pkg_dict):
     return [{'name': g['value'], 'title_translated': g['label']}
             for g in groups
             if g['value'] not in package_group_ids]
+
+
+highvalue_categories = {
+    "meteorological": "Meteorological",
+    "companies-and-company-ownership": "Companies and company ownership",
+    "geospatial": "Geospatial",
+    "mobility": "Mobility",
+    "earth-observation-and-environment": "Earth observation and environment",
+    "statistics": "Statistics"
+}
+
+def scheming_highvalue_category_list(field):
+    return [{"value": category, "label": highvalue_categories[category] } for category in highvalue_categories]
+
+def get_highvalue_category_label(value):
+    return highvalue_categories.get(value, "")

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/helpers.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/helpers.py
@@ -228,7 +228,7 @@ highvalue_categories = {
 }
 
 def scheming_highvalue_category_list(field):
-    return [{"value": category, "label": highvalue_categories[category] } for category in highvalue_categories]
+    return [{"value": category, "label": label } for category, label in highvalue_categories.items()]
 
 def get_highvalue_category_label(value):
     return highvalue_categories.get(value, "")

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
@@ -166,7 +166,7 @@ class RestrictedDataPlugin(plugins.SingletonPlugin, DefaultTranslation):
     def dataset_facets(self, facets_dict, package_type):
         lang = helpers.get_lang_prefix()
         facets_dict = OrderedDict([
-            ('groups', toolkit._('Datasets')),
+            ('groups', toolkit._('Groups')),
             ('vocab_keywords_' + lang, toolkit._('Tags')),
             ('res_format', toolkit._('Format')),
         ])

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
@@ -73,6 +73,8 @@ class RestrictedDataPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'build_nav_main': helpers.build_nav_main,
             'get_translated_logo': helpers.get_translated_logo,
             'get_assignable_groups_for_package': helpers.get_assignable_groups_for_package,
+            'scheming_highvalue_category_list': helpers.scheming_highvalue_category_list,
+            'get_highvalue_category_label': helpers.get_highvalue_category_label
         }
 
     # IValidators:
@@ -98,6 +100,16 @@ class RestrictedDataPlugin(plugins.SingletonPlugin, DefaultTranslation):
     # IPackageController
 
     def after_dataset_search(self, search_results, search_params) -> PackageDict:
+
+        # Modify facet display name to be human-readable
+        # TODO: handle translations for groups and highvalue categories
+        if search_results.get('search_facets'):
+            for facet in search_results['search_facets']:
+                if facet == "vocab_highvalue_category":
+                    for facet_item in search_results['search_facets'][facet]['items']:
+                        facet_item['display_name'] = helpers.get_highvalue_category_label(facet_item['name'])
+
+
         # Only filter results if processing a request
         if not has_request_context():
             return search_results
@@ -153,6 +165,9 @@ class RestrictedDataPlugin(plugins.SingletonPlugin, DefaultTranslation):
             for language in languages:
                 if prop_value.get(language):
                     pkg_dict['vocab_%s_%s' % (prop_key, language)] = [tag.lower() for tag in prop_value[language]]
+
+        if pkg_dict.get('highvalue_category'):
+            pkg_dict['vocab_highvalue_category'] = json.loads(pkg_dict.get('highvalue_category'))
 
         return pkg_dict
 

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/schemas/dataset.json
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/schemas/dataset.json
@@ -130,34 +130,10 @@
       "visual_required": true,
       "hideable": true,
       "preset": "multiple_checkbox",
-      "choices": [
-        {
-          "value": "meteorological",
-          "label": "Meteorological"
-        },
-        {
-          "value": "companies-and-company-ownership",
-          "label": "Companies and company ownership"
-          },
-        {
-          "value": "geospatial",
-          "label": "Geospatial"
-        },
-        {
-          "value": "mobility",
-          "label": "Mobility"
-        },
-        {
-          "value": "earth-observation-and-environment",
-          "label": "Earth observation and environment"
-        },
-        {
-          "value": "statistics",
-          "label": "Statistics"
-        }
-      ],
+      "choices_helper": "scheming_highvalue_category_list",
       "validators": "highvalue_category scheming_multiple_choice",
-      "description": "Select at least one category."
+      "description": "Select at least one category.",
+      "display_snippet": "tag_list.html"
     },
     {
       "field_name": "access_rights",

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/scheming/display_snippets/tag_list.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/scheming/display_snippets/tag_list.html
@@ -1,0 +1,24 @@
+{%- set values = data[field.field_name] -%}
+{%- set tags = [] -%}
+
+{%- for choice in h.scheming_field_choices(field) -%}
+  {%- if choice.value in values -%}
+    {%- do tags.append((choice.value, h.scheming_language_text(choice.label))) -%}
+  {%- endif -%}
+{%- endfor -%}
+
+  <ul class="tag-list">
+    {%- for value, label in tags -%}
+      {% set tag_dict = dict({
+        'controller': 'dataset',
+        'action': 'search',
+        'vocab_' + field.field_name : value }) %}
+      <li>
+        <a class="{% block tag_list_item_class %}tag{% endblock %}" href="{{ h.call_toolkit_function('url_for',[], tag_dict) }}">
+        {{ h.truncate(label, 22) }}
+        </a>
+      </li>
+    {%- endfor -%}
+  </ul>
+
+

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
@@ -163,7 +163,7 @@ def test_dataset_with_highvalue_category_as_normal_user(app):
     assert dataset['highvalue_category'] == ["geospatial"]
 
 
-@pytest.mark.usefixtures("clean_db", "with_plugins")
+@pytest.mark.usefixtures("clean_db", "clean_index", "with_plugins")
 def test_search_facets_with_highvalue_category():
     dataset_fields = minimal_dataset_with_one_resource_fields(Sysadmin())
     dataset_fields['highvalue'] = True

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
@@ -168,7 +168,7 @@ def test_search_facets_with_highvalue_category():
     dataset_fields = minimal_dataset_with_one_resource_fields(Sysadmin())
     dataset_fields['highvalue'] = True
     dataset_fields['highvalue_category'] = ["earth-observation-and-environment"]
-    d = Dataset(**dataset_fields)
+    Dataset(**dataset_fields)
     data_dict = {
         "facet.field": ['vocab_highvalue_category']
     }

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
@@ -164,6 +164,30 @@ def test_dataset_with_highvalue_category_as_normal_user(app):
 
 
 @pytest.mark.usefixtures("clean_db", "with_plugins")
+def test_search_facets_with_highvalue_category():
+    dataset_fields = minimal_dataset_with_one_resource_fields(Sysadmin())
+    dataset_fields['highvalue'] = True
+    dataset_fields['highvalue_category'] = ["earth-observation-and-environment"]
+    d = Dataset(**dataset_fields)
+    data_dict = {
+        "facet.field": ['vocab_highvalue_category']
+    }
+    results = call_action('package_search', **data_dict )
+    assert results['search_facets'] == {
+        "vocab_highvalue_category": {
+            "items": [
+                {
+                    "count": 1,
+                    "display_name": "Earth observation and environment",
+                    "name": "earth-observation-and-environment"
+                }
+            ],
+            "title": "vocab_highvalue_category"
+        }
+    }
+
+
+@pytest.mark.usefixtures("clean_db", "with_plugins")
 def test_dataset_with_external_ursl():
     dataset_fields = minimal_dataset_with_one_resource_fields(Sysadmin())
     dataset_fields['external_urls'] = ['http://example.com', 'https://example.com']


### PR DESCRIPTION
Indexes highvalue categories to vocab index, so that schema doesn't need to be changed. Modifies facet presentation for highvalue categories they don't need to be added as actual vocabularies. Moves the definition of hvd categories to helper to have a single list for them and not define them in multiple places.

Translations are marked as todo on purpose as categories (as in groups) aren't translated either, they need to be solved properly.

Fixes facet label of groups as it said datasets for some reason.