### PR TITLE
REKDAT-162: Fix footer link translations

### DIFF
--- a/robot/restricteddata.robot
+++ b/robot/restricteddata.robot
@@ -47,6 +47,10 @@ Open Browser To Login Page
 Login Page Should Be Open
     Title Should Be    Kirjaudu - Suojattudata
 
+Go To Front Page
+    Go To    ${INDEX URL}
+    Front Page Should Be Open
+
 Go To Login Page
     Go To    ${LOGIN URL}
     Login Page Should Be Open

--- a/robot/tests/pages.robot
+++ b/robot/tests/pages.robot
@@ -1,0 +1,65 @@
+*** Settings ***
+Documentation     A CMS test suite.
+Resource          ../restricteddata.robot
+Test Setup        Reset Data And Open Front Page
+Test Teardown     Close Chromium
+
+*** Test Cases ***
+Create A Header Nav Page
+    Log In As Administrator
+    Open URL Path  /pages_edit
+    Fill Pages Form With Test Data
+    Select From List By Value  submenu_order  1
+    Submit Form  css:.pages-form
+    URL Path Should Be  /pages/test
+    Log Out
+
+    Go To Front Page
+    Element Should Contain  css:header .navbar  Title fi
+
+    Click Element  id:language-select-dropdown
+    Click Element  partial link:(EN)
+    Element Should Contain  css:header .navbar  Title en
+
+    Click Element  id:language-select-dropdown
+    Click Element  partial link:(SV)
+    Element Should Contain  css:header .navbar  Title sv
+
+    Element Should Not Contain  css:.footer-links  Title
+
+Create A Footer Nav Page
+    Log In As Administrator
+    Open URL Path  /pages_edit
+    Fill Pages Form With Test Data
+    Select From List By Index  order  1
+    Submit Form  css:.pages-form
+    URL Path Should Be  /pages/test
+    Log Out
+
+    Go To Front Page
+    Element Should Contain  css:.footer-links  Title fi
+
+    Click Element  id:language-select-dropdown
+    Click Element  partial link:(EN)
+    Element Should Contain  css:.footer-links  Title en
+
+    Click Element  id:language-select-dropdown
+    Click Element  partial link:(SV)
+    Element Should Contain  css:.footer-links  Title sv
+
+    Element Should Not Contain  css:header .navbar  Title
+
+*** Keywords ***
+Fill Pages Form With Test Data
+    Input Text  title  Test
+    Input Text  publish_date  2024-06-25
+    Input Text  title_fi  Title fi
+    Input Text  title_sv  Title sv
+    Input Text  title_en  Title en
+    Input Text  content_fi  Content fi
+    Input Text  content_sv  Content sv
+    Input Text  content_en  Content en
+    Select From List By Index  submenu_order  0
+    Select From List By Value  private  False
+    Select From List By Index  order  0
+ 

--- a/robot/tests/pages.robot
+++ b/robot/tests/pages.robot
@@ -16,6 +16,7 @@ Create A Header Nav Page
     Log Out
 
     Go To Front Page
+    Reload Page  # CKAN cache shows old front page without this
     Element Should Contain  css:header .navbar  Title fi
 
     Click Element  id:language-select-dropdown
@@ -39,6 +40,7 @@ Create A Footer Nav Page
     Log Out
 
     Go To Front Page
+    Reload Page  # CKAN cache shows old front page without this
     Element Should Contain  css:.footer-links  Title fi
 
     Click Element  id:language-select-dropdown

--- a/robot/tests/pages.robot
+++ b/robot/tests/pages.robot
@@ -12,6 +12,7 @@ Create A Header Nav Page
     Select From List By Value  submenu_order  1
     Submit Form  css:.pages-form
     URL Path Should Be  /pages/test
+    Element Should Contain  css:h1.page-heading  Title fi
     Log Out
 
     Go To Front Page
@@ -34,6 +35,7 @@ Create A Footer Nav Page
     Select From List By Index  order  1
     Submit Form  css:.pages-form
     URL Path Should Be  /pages/test
+    Element Should Contain  css:h1.page-heading  Title fi
     Log Out
 
     Go To Front Page

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-select = ["E", "F"]
+lint.select = ["E", "F"]
 
 extend-exclude = [
   "ckanext-dcat",


### PR DESCRIPTION
- Override ckanext-pages nav build function as it does not support multilingual titles
- Fix deprecated ruff setting
- Added tests for creating header/footer pages items (no unit test due to cross-extension behavior)