### PR TITLE
REKDAT-160: Update DCAT-AP ns page

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/doc/dcat-ap/README.md
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/doc/dcat-ap/README.md
@@ -47,6 +47,7 @@ A catalogue or repository that hosts the Datasets being described.
 #### Properties
 
 
+
 ##### Mandatory
 Term | Range | Cardinality | Comment
 -----|-------|-------------|--------
@@ -56,29 +57,17 @@ dct:publisher | foaf:Agent | 1..1 | This property refers to an entity (organisat
 dct:title | rdfs:Literal | 1..n | This property contains a name given to the Catalogue. This property can be repeated for parallel language versions of the name.
  
 
+
+
 ##### Recommended
 Term | Range | Cardinality | Comment
 -----|-------|-------------|--------
 foaf:homepage | foaf:Document | 0..1 | This property refers to a web page that acts as the main page for the Catalogue.
 dct:language | dct:LinguisticSystem | 0..n | This property refers to a language used in the textual metadata describing titles, descriptions, etc. of the Datasets in the Catalogue. This property can be repeated if the metadata is provided in multiple languages.
-dct:license | dct:LicenseDocument | 0..1 | This property refers to the licence under which the Catalogue can be used or reused.
-dct:issued | rdfs:Literal typed as xsd:date or xsd:dateTime | 0..1 | This property contains the date of formal issuance (e.g., publication) of the Catalogue.
-dct:spatial | dct:Location | 0..n | This property refers to a geographical area covered by the Catalogue.
-dcat:themeTaxonomy | skos:ConceptScheme | 0..n | This property refers to a knowledge organization system used to classify the Catalogue's Datasets.
-dct:modified | rdfs:Literal typed as xsd:date or xsd:dateTime | 0..1 | This property contains the most recent date on which the Catalogue was modified.
  
 
-##### Optional
-Term | Range | Cardinality | Comment
------|-------|-------------|--------
-dct:hasPart | dcat:Catalog | 0..n | This property refers to a related Catalogue that is part of the described Catalogue
-dct:isPartOf | dcat:Catalog | 0..1 | This property refers to a related Catalogue in which the described Catalogue is physically or logically included.
-dcat:record | dcat:CatalogRecord | 0..n | This property refers to a Catalogue Record that is part of the Catalogue
-dct:rights | dct:RightsStatement | 0..1 | This property refers to a statement that specifies rights associated with the Catalogue.
-dcat:service | dcat:DataService | 0..n | This property refers to a site or end-point that is listed in the catalog.
-dcat:catalog | dcat:Catalog | 0..n | This property refers to a catalog whose contents are of interest in the context of this catalog
-dct:creator | foaf:Agent | 0..1 | This property refers to the  entity primarily responsible for producing the catalogue
- 
+
+
  
 
 ### Dataset
@@ -90,12 +79,15 @@ A conceptual entity that represents the information published.
 #### Properties
 
 
+
 ##### Mandatory
 Term | Range | Cardinality | Comment
 -----|-------|-------------|--------
 dct:description | rdfs:Literal | 1..n | This property contains a free-text account of the Dataset. This property can be repeated for parallel language versions of the description.
 dct:title | rdfs:Literal | 1..n | This property contains a name given to the Dataset. This property can be repeated for parallel language versions of the name.
  
+
+
 
 ##### Recommended
 Term | Range | Cardinality | Comment
@@ -109,6 +101,8 @@ dct:temporal | dct:PeriodOfTime | 0..1 | This property refers to a temporal peri
 dcat:theme, subproperty of dct:subject | skos:Concept | 0..n | This property refers to a category of the Dataset. A Dataset may be associated with multiple themes.
  
 
+
+
 ##### Optional
 Term | Range | Cardinality | Comment
 -----|-------|-------------|--------
@@ -120,6 +114,7 @@ dct:issued | rdfs:Literal typed as xsd:date or xsd:dateTime | 0..1 | This proper
 dct:type | skos:Concept | 0..1 | This property refers to the type of the Dataset. A controlled vocabulary for the values has not been established.
 dct:modified | rdfs:Literal typed as xsd:date or xsd:dateTime | 0..1 | This property contains the most recent date on which the Dataset was changed or modified.
  
+
  
 
 ### Distribution
@@ -131,11 +126,14 @@ A physical embodiment of the Dataset in a particular format.
 #### Properties
 
 
+
 ##### Mandatory
 Term | Range | Cardinality | Comment
 -----|-------|-------------|--------
 dcat:accessURL | rdfs:Resource | 1..n | This property contains a URL that gives access to a Distribution of the Dataset. The resource at the access URL may contain information about how to get the Dataset.
  
+
+
 
 ##### Recommended
 Term | Range | Cardinality | Comment
@@ -144,6 +142,8 @@ dct:description | rdfs:Literal | 0..n | This property contains a free-text accou
 dct:format | dct:MediaTypeOrExtent | 0..1 | This property refers to the file format of the Distribution.
 dct:license | dct:LicenseDocument | 0..1 | This property refers to the licence under which the Distribution is made available.
  
+
+
 
 ##### Optional
 Term | Range | Cardinality | Comment
@@ -160,5 +160,6 @@ dcat:temporalResolution | xsd:duration | 0..n | This property refers to the mini
 dct:title | rdfs:Literal | 0..n | This property contains a name given to the Distribution. This property can be repeated for parallel language versions of the description.
 dct:modified | rdfs:Literal typed as xsd:date or xsd:dateTime | 0..1 | This property contains the most recent date on which the Distribution was changed or modified.
  
+
  
  

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/doc/dcat-ap/README.md
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/doc/dcat-ap/README.md
@@ -33,6 +33,7 @@ voaf | http://purl.org/vocommons/voaf#
 vcard | http://www.w3.org/2006/vcard/ns#
 geodcat | http://data.europa.eu/930/#
 gsp | http://www.opengis.net/ont/geosparql#
+hvd | https://semiceu.github.io/uri.semic.eu-generated/DCAT-AP/releases/2.2.0-hvd/#
 
 
 ## Classes
@@ -113,6 +114,8 @@ dcat:landingPage | foaf:Document | 0..n | This property refers to a web page tha
 dct:issued | rdfs:Literal typed as xsd:date or xsd:dateTime | 0..1 | This property contains the date of formal issuance (e.g., publication) of the Dataset.
 dct:type | skos:Concept | 0..1 | This property refers to the type of the Dataset. A controlled vocabulary for the values has not been established.
 dct:modified | rdfs:Literal typed as xsd:date or xsd:dateTime | 0..1 | This property contains the most recent date on which the Dataset was changed or modified.
+dcatap:hvdCategory | skos:Concept | 0..n | The HVD category to which this Dataset belongs.
+dcatap:applicableLegislation | hvd:LegalResource | 0..n | The legislation that mandates the creation or management of the Dataset.
  
 
  
@@ -159,6 +162,7 @@ dcat:temporalResolution | xsd:duration | 0..n | This property refers to the mini
 **dct:temporal** | dct:PeriodOfTime | 0..n | This property refers to a temporal period that the Distribution covers.
 dct:title | rdfs:Literal | 0..n | This property contains a name given to the Distribution. This property can be repeated for parallel language versions of the description.
 dct:modified | rdfs:Literal typed as xsd:date or xsd:dateTime | 0..1 | This property contains the most recent date on which the Distribution was changed or modified.
+dcatap:applicableLegislation | hvd:LegalResource | 0..n | The legislation that mandates the creation or management of the Dataset.
  
 
  

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/doc/dcat-ap/index.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/doc/dcat-ap/index.html
@@ -44,6 +44,7 @@
       <tr><td>vcard</td><td>http://www.w3.org/2006/vcard/ns#</td></tr>
       <tr><td>geodcat</td><td>http://data.europa.eu/930/#</td></tr>
       <tr><td>gsp</td><td>http://www.opengis.net/ont/geosparql#</td></tr>
+      <tr><td>hvd</td><td>https://semiceu.github.io/uri.semic.eu-generated/DCAT-AP/releases/2.2.0-hvd/#</td></tr>
       
       </tbody>
     </table>
@@ -261,6 +262,18 @@
             <td>0..1</td>
             <td>This property contains the most recent date on which the Dataset was changed or modified.</td>
           </tr>
+        <tr>
+            <td>dcatap:hvdCategory </td>
+            <td>skos:Concept</td>
+            <td>0..n</td>
+            <td>The HVD category to which this Dataset belongs.</td>
+          </tr>
+        <tr>
+            <td>dcatap:applicableLegislation </td>
+            <td>hvd:LegalResource</td>
+            <td>0..n</td>
+            <td>The legislation that mandates the creation or management of the Dataset.</td>
+          </tr>
          
         </tbody>
       </table>
@@ -397,6 +410,12 @@
             <td>rdfs:Literal typed as xsd:date or xsd:dateTime</td>
             <td>0..1</td>
             <td>This property contains the most recent date on which the Distribution was changed or modified.</td>
+          </tr>
+        <tr>
+            <td>dcatap:applicableLegislation </td>
+            <td>hvd:LegalResource</td>
+            <td>0..n</td>
+            <td>The legislation that mandates the creation or management of the Dataset.</td>
           </tr>
          
         </tbody>

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/doc/dcat-ap/index.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/doc/dcat-ap/index.html
@@ -61,143 +61,67 @@
     <h4>Properties</h4>
 
     
-    <table class="table table-striped">
-      <caption>Mandatory properties</caption>
-      <thead>
-        <tr><th>Term</th><th>Range</th><th>Cardinality</th><th>Comment</th></tr>
-      </thead>
-      <tbody>
-      <tr>
-          <td>dcat:dataset </td>
-          <td>dcat:Dataset</td>
-          <td>1..n</td>
-          <td>This property links the Catalogue with a Dataset that is part of the Catalogue.</td>
-        </tr>
-      <tr>
-          <td>dct:description </td>
-          <td>rdfs:Literal</td>
-          <td>1..n</td>
-          <td>This property contains a free-text account of the Catalogue. This property can be repeated for parallel language versions of the description. For further information on multilingual issues, please refer to section 8.</td>
-        </tr>
-      <tr>
-          <td>dct:publisher </td>
-          <td>foaf:Agent</td>
-          <td>1..1</td>
-          <td>This property refers to an entity (organisation) responsible for making the Catalogue available.</td>
-        </tr>
-      <tr>
-          <td>dct:title </td>
-          <td>rdfs:Literal</td>
-          <td>1..n</td>
-          <td>This property contains a name given to the Catalogue. This property can be repeated for parallel language versions of the name.</td>
-        </tr>
-       
-      </tbody>
-    </table>
+      
+      <table class="table table-striped">
+        <caption>Mandatory properties</caption>
+        <thead>
+          <tr><th>Term</th><th>Range</th><th>Cardinality</th><th>Comment</th></tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>dcat:dataset </td>
+            <td>dcat:Dataset</td>
+            <td>1..n</td>
+            <td>This property links the Catalogue with a Dataset that is part of the Catalogue.</td>
+          </tr>
+        <tr>
+            <td>dct:description </td>
+            <td>rdfs:Literal</td>
+            <td>1..n</td>
+            <td>This property contains a free-text account of the Catalogue. This property can be repeated for parallel language versions of the description. For further information on multilingual issues, please refer to section 8.</td>
+          </tr>
+        <tr>
+            <td>dct:publisher </td>
+            <td>foaf:Agent</td>
+            <td>1..1</td>
+            <td>This property refers to an entity (organisation) responsible for making the Catalogue available.</td>
+          </tr>
+        <tr>
+            <td>dct:title </td>
+            <td>rdfs:Literal</td>
+            <td>1..n</td>
+            <td>This property contains a name given to the Catalogue. This property can be repeated for parallel language versions of the name.</td>
+          </tr>
+         
+        </tbody>
+      </table>
+      
     
-    <table class="table table-striped">
-      <caption>Recommended properties</caption>
-      <thead>
-        <tr><th>Term</th><th>Range</th><th>Cardinality</th><th>Comment</th></tr>
-      </thead>
-      <tbody>
-      <tr>
-          <td>foaf:homepage </td>
-          <td>foaf:Document</td>
-          <td>0..1</td>
-          <td>This property refers to a web page that acts as the main page for the Catalogue.</td>
-        </tr>
-      <tr>
-          <td>dct:language </td>
-          <td>dct:LinguisticSystem</td>
-          <td>0..n</td>
-          <td>This property refers to a language used in the textual metadata describing titles, descriptions, etc. of the Datasets in the Catalogue. This property can be repeated if the metadata is provided in multiple languages.</td>
-        </tr>
-      <tr>
-          <td>dct:license </td>
-          <td>dct:LicenseDocument</td>
-          <td>0..1</td>
-          <td>This property refers to the licence under which the Catalogue can be used or reused.</td>
-        </tr>
-      <tr>
-          <td>dct:issued </td>
-          <td>rdfs:Literal typed as xsd:date or xsd:dateTime</td>
-          <td>0..1</td>
-          <td>This property contains the date of formal issuance (e.g., publication) of the Catalogue.</td>
-        </tr>
-      <tr>
-          <td>dct:spatial </td>
-          <td>dct:Location</td>
-          <td>0..n</td>
-          <td>This property refers to a geographical area covered by the Catalogue.</td>
-        </tr>
-      <tr>
-          <td>dcat:themeTaxonomy </td>
-          <td>skos:ConceptScheme</td>
-          <td>0..n</td>
-          <td>This property refers to a knowledge organization system used to classify the Catalogue's Datasets.</td>
-        </tr>
-      <tr>
-          <td>dct:modified </td>
-          <td>rdfs:Literal typed as xsd:date or xsd:dateTime</td>
-          <td>0..1</td>
-          <td>This property contains the most recent date on which the Catalogue was modified.</td>
-        </tr>
-       
-      </tbody>
-    </table>
+      
+      <table class="table table-striped">
+        <caption>Recommended properties</caption>
+        <thead>
+          <tr><th>Term</th><th>Range</th><th>Cardinality</th><th>Comment</th></tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>foaf:homepage </td>
+            <td>foaf:Document</td>
+            <td>0..1</td>
+            <td>This property refers to a web page that acts as the main page for the Catalogue.</td>
+          </tr>
+        <tr>
+            <td>dct:language </td>
+            <td>dct:LinguisticSystem</td>
+            <td>0..n</td>
+            <td>This property refers to a language used in the textual metadata describing titles, descriptions, etc. of the Datasets in the Catalogue. This property can be repeated if the metadata is provided in multiple languages.</td>
+          </tr>
+         
+        </tbody>
+      </table>
+      
     
-    <table class="table table-striped">
-      <caption>Optional properties</caption>
-      <thead>
-        <tr><th>Term</th><th>Range</th><th>Cardinality</th><th>Comment</th></tr>
-      </thead>
-      <tbody>
-      <tr>
-          <td>dct:hasPart </td>
-          <td>dcat:Catalog</td>
-          <td>0..n</td>
-          <td>This property refers to a related Catalogue that is part of the described Catalogue</td>
-        </tr>
-      <tr>
-          <td>dct:isPartOf </td>
-          <td>dcat:Catalog</td>
-          <td>0..1</td>
-          <td>This property refers to a related Catalogue in which the described Catalogue is physically or logically included.</td>
-        </tr>
-      <tr>
-          <td>dcat:record </td>
-          <td>dcat:CatalogRecord</td>
-          <td>0..n</td>
-          <td>This property refers to a Catalogue Record that is part of the Catalogue</td>
-        </tr>
-      <tr>
-          <td>dct:rights </td>
-          <td>dct:RightsStatement</td>
-          <td>0..1</td>
-          <td>This property refers to a statement that specifies rights associated with the Catalogue.</td>
-        </tr>
-      <tr>
-          <td>dcat:service </td>
-          <td>dcat:DataService</td>
-          <td>0..n</td>
-          <td>This property refers to a site or end-point that is listed in the catalog.</td>
-        </tr>
-      <tr>
-          <td>dcat:catalog </td>
-          <td>dcat:Catalog</td>
-          <td>0..n</td>
-          <td>This property refers to a catalog whose contents are of interest in the context of this catalog</td>
-        </tr>
-      <tr>
-          <td>dct:creator </td>
-          <td>foaf:Agent</td>
-          <td>0..1</td>
-          <td>This property refers to the  entity primarily responsible for producing the catalogue</td>
-        </tr>
-       
-      </tbody>
-    </table>
+      
      
     
     <h3 id="Dataset">Dataset</h3>
@@ -210,131 +134,137 @@
     <h4>Properties</h4>
 
     
-    <table class="table table-striped">
-      <caption>Mandatory properties</caption>
-      <thead>
-        <tr><th>Term</th><th>Range</th><th>Cardinality</th><th>Comment</th></tr>
-      </thead>
-      <tbody>
-      <tr>
-          <td>dct:description </td>
-          <td>rdfs:Literal</td>
-          <td>1..n</td>
-          <td>This property contains a free-text account of the Dataset. This property can be repeated for parallel language versions of the description.</td>
-        </tr>
-      <tr>
-          <td>dct:title </td>
-          <td>rdfs:Literal</td>
-          <td>1..n</td>
-          <td>This property contains a name given to the Dataset. This property can be repeated for parallel language versions of the name.</td>
-        </tr>
-       
-      </tbody>
-    </table>
+      
+      <table class="table table-striped">
+        <caption>Mandatory properties</caption>
+        <thead>
+          <tr><th>Term</th><th>Range</th><th>Cardinality</th><th>Comment</th></tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>dct:description </td>
+            <td>rdfs:Literal</td>
+            <td>1..n</td>
+            <td>This property contains a free-text account of the Dataset. This property can be repeated for parallel language versions of the description.</td>
+          </tr>
+        <tr>
+            <td>dct:title </td>
+            <td>rdfs:Literal</td>
+            <td>1..n</td>
+            <td>This property contains a name given to the Dataset. This property can be repeated for parallel language versions of the name.</td>
+          </tr>
+         
+        </tbody>
+      </table>
+      
     
-    <table class="table table-striped">
-      <caption>Recommended properties</caption>
-      <thead>
-        <tr><th>Term</th><th>Range</th><th>Cardinality</th><th>Comment</th></tr>
-      </thead>
-      <tbody>
-      <tr>
-          <td>dcat:contactPoint </td>
-          <td>vcard:Kind</td>
-          <td>0..n</td>
-          <td>This property contains contact information that can be used for sending comments about the Dataset.</td>
-        </tr>
-      <tr>
-          <td>dcat:distribution </td>
-          <td>dcat:Distribution</td>
-          <td>0..n</td>
-          <td>This property links the Dataset to an available Distribution.</td>
-        </tr>
-      <tr>
-          <td>dcat:keyword </td>
-          <td>rdfs:Literal</td>
-          <td>0..n</td>
-          <td>This property contains a keyword or tag describing the Dataset.</td>
-        </tr>
-      <tr>
-          <td>dct:publisher </td>
-          <td>foaf:Agent</td>
-          <td>0..1</td>
-          <td>This property refers to an entity (organisation) responsible for making the Dataset available.</td>
-        </tr>
-      <tr>
-          <td>dct:spatial </td>
-          <td>dct:Location</td>
-          <td>0..n</td>
-          <td>This property refers to a geographic region that is covered by the Dataset.</td>
-        </tr>
-      <tr>
-          <td>dct:temporal </td>
-          <td>dct:PeriodOfTime</td>
-          <td>0..1</td>
-          <td>This property refers to a temporal period that the Dataset covers.</td>
-        </tr>
-      <tr>
-          <td>dcat:theme, subproperty of dct:subject </td>
-          <td>skos:Concept</td>
-          <td>0..n</td>
-          <td>This property refers to a category of the Dataset. A Dataset may be associated with multiple themes.</td>
-        </tr>
-       
-      </tbody>
-    </table>
+      
+      <table class="table table-striped">
+        <caption>Recommended properties</caption>
+        <thead>
+          <tr><th>Term</th><th>Range</th><th>Cardinality</th><th>Comment</th></tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>dcat:contactPoint </td>
+            <td>vcard:Kind</td>
+            <td>0..n</td>
+            <td>This property contains contact information that can be used for sending comments about the Dataset.</td>
+          </tr>
+        <tr>
+            <td>dcat:distribution </td>
+            <td>dcat:Distribution</td>
+            <td>0..n</td>
+            <td>This property links the Dataset to an available Distribution.</td>
+          </tr>
+        <tr>
+            <td>dcat:keyword </td>
+            <td>rdfs:Literal</td>
+            <td>0..n</td>
+            <td>This property contains a keyword or tag describing the Dataset.</td>
+          </tr>
+        <tr>
+            <td>dct:publisher </td>
+            <td>foaf:Agent</td>
+            <td>0..1</td>
+            <td>This property refers to an entity (organisation) responsible for making the Dataset available.</td>
+          </tr>
+        <tr>
+            <td>dct:spatial </td>
+            <td>dct:Location</td>
+            <td>0..n</td>
+            <td>This property refers to a geographic region that is covered by the Dataset.</td>
+          </tr>
+        <tr>
+            <td>dct:temporal </td>
+            <td>dct:PeriodOfTime</td>
+            <td>0..1</td>
+            <td>This property refers to a temporal period that the Dataset covers.</td>
+          </tr>
+        <tr>
+            <td>dcat:theme, subproperty of dct:subject </td>
+            <td>skos:Concept</td>
+            <td>0..n</td>
+            <td>This property refers to a category of the Dataset. A Dataset may be associated with multiple themes.</td>
+          </tr>
+         
+        </tbody>
+      </table>
+      
     
-    <table class="table table-striped">
-      <caption>Optional properties</caption>
-      <thead>
-        <tr><th>Term</th><th>Range</th><th>Cardinality</th><th>Comment</th></tr>
-      </thead>
-      <tbody>
-      <tr>
-          <td>dct:accessRights </td>
-          <td>dct:RightsStatement</td>
-          <td>0..1</td>
-          <td>This property refers to information that indicates whether the Dataset is open data, has access restrictions or is not public. A controlled vocabulary with three members (:public, :restricted, :non-public) will be created and maintained by the Publications Office of the EU.</td>
-        </tr>
-      <tr>
-          <td>dct:accrualPeriodicity </td>
-          <td>dct:Frequency</td>
-          <td>0..1</td>
-          <td>This property refers to the frequency at which the Dataset is updated.</td>
-        </tr>
-      <tr>
-          <td>dct:identifier </td>
-          <td>rdfs:Literal</td>
-          <td>0..n</td>
-          <td>This property contains the main identifier for the Dataset, e.g. the URI or other unique identifier in the context of the Catalogue.</td>
-        </tr>
-      <tr>
-          <td>dcat:landingPage </td>
-          <td>foaf:Document</td>
-          <td>0..n</td>
-          <td>This property refers to a web page that provides access to the Dataset, its Distributions and/or additional information. It is intended to point to a landing page at the original data provider, not to a page on a site of a third party, such as an aggregator.</td>
-        </tr>
-      <tr>
-          <td>dct:issued </td>
-          <td>rdfs:Literal typed as xsd:date or xsd:dateTime</td>
-          <td>0..1</td>
-          <td>This property contains the date of formal issuance (e.g., publication) of the Dataset.</td>
-        </tr>
-      <tr>
-          <td>dct:type </td>
-          <td>skos:Concept</td>
-          <td>0..1</td>
-          <td>This property refers to the type of the Dataset. A controlled vocabulary for the values has not been established.</td>
-        </tr>
-      <tr>
-          <td>dct:modified </td>
-          <td>rdfs:Literal typed as xsd:date or xsd:dateTime</td>
-          <td>0..1</td>
-          <td>This property contains the most recent date on which the Dataset was changed or modified.</td>
-        </tr>
-       
-      </tbody>
-    </table>
+      
+      <table class="table table-striped">
+        <caption>Optional properties</caption>
+        <thead>
+          <tr><th>Term</th><th>Range</th><th>Cardinality</th><th>Comment</th></tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>dct:accessRights </td>
+            <td>dct:RightsStatement</td>
+            <td>0..1</td>
+            <td>This property refers to information that indicates whether the Dataset is open data, has access restrictions or is not public. A controlled vocabulary with three members (:public, :restricted, :non-public) will be created and maintained by the Publications Office of the EU.</td>
+          </tr>
+        <tr>
+            <td>dct:accrualPeriodicity </td>
+            <td>dct:Frequency</td>
+            <td>0..1</td>
+            <td>This property refers to the frequency at which the Dataset is updated.</td>
+          </tr>
+        <tr>
+            <td>dct:identifier </td>
+            <td>rdfs:Literal</td>
+            <td>0..n</td>
+            <td>This property contains the main identifier for the Dataset, e.g. the URI or other unique identifier in the context of the Catalogue.</td>
+          </tr>
+        <tr>
+            <td>dcat:landingPage </td>
+            <td>foaf:Document</td>
+            <td>0..n</td>
+            <td>This property refers to a web page that provides access to the Dataset, its Distributions and/or additional information. It is intended to point to a landing page at the original data provider, not to a page on a site of a third party, such as an aggregator.</td>
+          </tr>
+        <tr>
+            <td>dct:issued </td>
+            <td>rdfs:Literal typed as xsd:date or xsd:dateTime</td>
+            <td>0..1</td>
+            <td>This property contains the date of formal issuance (e.g., publication) of the Dataset.</td>
+          </tr>
+        <tr>
+            <td>dct:type </td>
+            <td>skos:Concept</td>
+            <td>0..1</td>
+            <td>This property refers to the type of the Dataset. A controlled vocabulary for the values has not been established.</td>
+          </tr>
+        <tr>
+            <td>dct:modified </td>
+            <td>rdfs:Literal typed as xsd:date or xsd:dateTime</td>
+            <td>0..1</td>
+            <td>This property contains the most recent date on which the Dataset was changed or modified.</td>
+          </tr>
+         
+        </tbody>
+      </table>
+      
      
     
     <h3 id="Distribution">Distribution</h3>
@@ -347,125 +277,131 @@
     <h4>Properties</h4>
 
     
-    <table class="table table-striped">
-      <caption>Mandatory properties</caption>
-      <thead>
-        <tr><th>Term</th><th>Range</th><th>Cardinality</th><th>Comment</th></tr>
-      </thead>
-      <tbody>
-      <tr>
-          <td>dcat:accessURL </td>
-          <td>rdfs:Resource</td>
-          <td>1..n</td>
-          <td>This property contains a URL that gives access to a Distribution of the Dataset. The resource at the access URL may contain information about how to get the Dataset.</td>
-        </tr>
-       
-      </tbody>
-    </table>
+      
+      <table class="table table-striped">
+        <caption>Mandatory properties</caption>
+        <thead>
+          <tr><th>Term</th><th>Range</th><th>Cardinality</th><th>Comment</th></tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>dcat:accessURL </td>
+            <td>rdfs:Resource</td>
+            <td>1..n</td>
+            <td>This property contains a URL that gives access to a Distribution of the Dataset. The resource at the access URL may contain information about how to get the Dataset.</td>
+          </tr>
+         
+        </tbody>
+      </table>
+      
     
-    <table class="table table-striped">
-      <caption>Recommended properties</caption>
-      <thead>
-        <tr><th>Term</th><th>Range</th><th>Cardinality</th><th>Comment</th></tr>
-      </thead>
-      <tbody>
-      <tr>
-          <td>dct:description </td>
-          <td>rdfs:Literal</td>
-          <td>0..n</td>
-          <td>This property contains a free-text account of the Distribution. This property can be repeated for parallel language versions of the description.</td>
-        </tr>
-      <tr>
-          <td>dct:format </td>
-          <td>dct:MediaTypeOrExtent</td>
-          <td>0..1</td>
-          <td>This property refers to the file format of the Distribution.</td>
-        </tr>
-      <tr>
-          <td>dct:license </td>
-          <td>dct:LicenseDocument</td>
-          <td>0..1</td>
-          <td>This property refers to the licence under which the Distribution is made available.</td>
-        </tr>
-       
-      </tbody>
-    </table>
+      
+      <table class="table table-striped">
+        <caption>Recommended properties</caption>
+        <thead>
+          <tr><th>Term</th><th>Range</th><th>Cardinality</th><th>Comment</th></tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>dct:description </td>
+            <td>rdfs:Literal</td>
+            <td>0..n</td>
+            <td>This property contains a free-text account of the Distribution. This property can be repeated for parallel language versions of the description.</td>
+          </tr>
+        <tr>
+            <td>dct:format </td>
+            <td>dct:MediaTypeOrExtent</td>
+            <td>0..1</td>
+            <td>This property refers to the file format of the Distribution.</td>
+          </tr>
+        <tr>
+            <td>dct:license </td>
+            <td>dct:LicenseDocument</td>
+            <td>0..1</td>
+            <td>This property refers to the licence under which the Distribution is made available.</td>
+          </tr>
+         
+        </tbody>
+      </table>
+      
     
-    <table class="table table-striped">
-      <caption>Optional properties</caption>
-      <thead>
-        <tr><th>Term</th><th>Range</th><th>Cardinality</th><th>Comment</th></tr>
-      </thead>
-      <tbody>
-      <tr>
-          <td>dcat:byteSize </td>
-          <td>rdfs:Literal typed as xsd:decimal</td>
-          <td>0..1</td>
-          <td>This property contains the size of a Distribution in bytes.</td>
-        </tr>
-      <tr>
-          <td>dcat:downloadURL </td>
-          <td>rdfs:Resource</td>
-          <td>0..n</td>
-          <td>This property contains a URL that is a direct link to a downloadable file in a given format.</td>
-        </tr>
-      <tr>
-          <td>dct:conformsTo </td>
-          <td>dct:Standard</td>
-          <td>0..n</td>
-          <td>This property refers to an established schema to which the described Distribution conforms.</td>
-        </tr>
-      <tr>
-          <td>dct:issued </td>
-          <td>rdfs:Literal typed as xsd:date or xsd:dateTime</td>
-          <td>0..1</td>
-          <td>This property contains the date of formal issuance (e.g., publication) of the Distribution.</td>
-        </tr>
-      <tr>
-          <td>dct:rights </td>
-          <td>dct:RightsStatement</td>
-          <td>0..1</td>
-          <td>This property refers to a statement that specifies rights associated with the Distribution.</td>
-        </tr>
-      <tr>
-          <td>dcat:spatialResolutionInMeters </td>
-          <td>xsd:decimal</td>
-          <td>0..n</td>
-          <td>This property refers to the  minimum spatial separation resolvable in a dataset distribution, measured in meters.</td>
-        </tr>
-      <tr>
-          <td>adms:status </td>
-          <td>skos:Concept</td>
-          <td>0..1</td>
-          <td>This property refers to the maturity of the Distribution. It MUST take one of the values Completed, Deprecated, Under Development, Withdrawn.</td>
-        </tr>
-      <tr>
-          <td>dcat:temporalResolution </td>
-          <td>xsd:duration</td>
-          <td>0..n</td>
-          <td>This property refers to the minimum time period resolvable in the dataset distribution.</td>
-        </tr>
-      <tr>
-          <td><strong>dct:temporal</strong></td>
-          <td>dct:PeriodOfTime</td>
-          <td>0..n</td>
-          <td>This property refers to a temporal period that the Distribution covers.</td>
-        </tr>
-      <tr>
-          <td>dct:title </td>
-          <td>rdfs:Literal</td>
-          <td>0..n</td>
-          <td>This property contains a name given to the Distribution. This property can be repeated for parallel language versions of the description.</td>
-        </tr>
-      <tr>
-          <td>dct:modified </td>
-          <td>rdfs:Literal typed as xsd:date or xsd:dateTime</td>
-          <td>0..1</td>
-          <td>This property contains the most recent date on which the Distribution was changed or modified.</td>
-        </tr>
-       
-      </tbody>
-    </table>
+      
+      <table class="table table-striped">
+        <caption>Optional properties</caption>
+        <thead>
+          <tr><th>Term</th><th>Range</th><th>Cardinality</th><th>Comment</th></tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>dcat:byteSize </td>
+            <td>rdfs:Literal typed as xsd:decimal</td>
+            <td>0..1</td>
+            <td>This property contains the size of a Distribution in bytes.</td>
+          </tr>
+        <tr>
+            <td>dcat:downloadURL </td>
+            <td>rdfs:Resource</td>
+            <td>0..n</td>
+            <td>This property contains a URL that is a direct link to a downloadable file in a given format.</td>
+          </tr>
+        <tr>
+            <td>dct:conformsTo </td>
+            <td>dct:Standard</td>
+            <td>0..n</td>
+            <td>This property refers to an established schema to which the described Distribution conforms.</td>
+          </tr>
+        <tr>
+            <td>dct:issued </td>
+            <td>rdfs:Literal typed as xsd:date or xsd:dateTime</td>
+            <td>0..1</td>
+            <td>This property contains the date of formal issuance (e.g., publication) of the Distribution.</td>
+          </tr>
+        <tr>
+            <td>dct:rights </td>
+            <td>dct:RightsStatement</td>
+            <td>0..1</td>
+            <td>This property refers to a statement that specifies rights associated with the Distribution.</td>
+          </tr>
+        <tr>
+            <td>dcat:spatialResolutionInMeters </td>
+            <td>xsd:decimal</td>
+            <td>0..n</td>
+            <td>This property refers to the  minimum spatial separation resolvable in a dataset distribution, measured in meters.</td>
+          </tr>
+        <tr>
+            <td>adms:status </td>
+            <td>skos:Concept</td>
+            <td>0..1</td>
+            <td>This property refers to the maturity of the Distribution. It MUST take one of the values Completed, Deprecated, Under Development, Withdrawn.</td>
+          </tr>
+        <tr>
+            <td>dcat:temporalResolution </td>
+            <td>xsd:duration</td>
+            <td>0..n</td>
+            <td>This property refers to the minimum time period resolvable in the dataset distribution.</td>
+          </tr>
+        <tr>
+            <td><strong>dct:temporal</strong></td>
+            <td>dct:PeriodOfTime</td>
+            <td>0..n</td>
+            <td>This property refers to a temporal period that the Distribution covers.</td>
+          </tr>
+        <tr>
+            <td>dct:title </td>
+            <td>rdfs:Literal</td>
+            <td>0..n</td>
+            <td>This property contains a name given to the Distribution. This property can be repeated for parallel language versions of the description.</td>
+          </tr>
+        <tr>
+            <td>dct:modified </td>
+            <td>rdfs:Literal typed as xsd:date or xsd:dateTime</td>
+            <td>0..1</td>
+            <td>This property contains the most recent date on which the Distribution was changed or modified.</td>
+          </tr>
+         
+        </tbody>
+      </table>
+      
      
      
 

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/doc/dcat-ap/model.yml
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/doc/dcat-ap/model.yml
@@ -80,79 +80,7 @@ classes:
           description: This property refers to a language used in the textual metadata describing titles, descriptions, etc. of the Datasets in the Catalogue. This property can be repeated if the metadata is provided in multiple languages.
           min: 0
           max: n
-#       - name: licence
-#         term: dct:license
-#         range: dct:LicenseDocument
-#         description: This property refers to the licence under which the Catalogue can be used or reused.
-#         min: 0
-#         max: 1
-#       - name: release date
-#         term: dct:issued
-#         range: rdfs:Literal typed as xsd:date or xsd:dateTime
-#         description: This property contains the date of formal issuance (e.g., publication) of the Catalogue.
-#         min: 0
-#         max: 1
-#       - name: spatial/ geographic
-#         term: dct:spatial
-#         range: dct:Location
-#         description: This property refers to a geographical area covered by the Catalogue. 
-#         min: 0
-#         max: n
-#       - name: themes
-#         term: dcat:themeTaxonomy
-#         range: skos:ConceptScheme
-#         description: This property refers to a knowledge organization system used to classify the Catalogue's Datasets.
-#         min: 0
-#         max: n
-#       - name: update/ modification date
-#         term: dct:modified
-#         range: rdfs:Literal typed as xsd:date or xsd:dateTime
-#         description: This property contains the most recent date on which the Catalogue was modified.
-#         min: 0
-#         max: 1
       optional: []
-#       - name: has part
-#         term: dct:hasPart
-#         range: dcat:Catalog
-#         description: This property refers to a related Catalogue that is part of the described Catalogue
-#         min: 0
-#         max: n
-#       - name: is part of
-#         term: dct:isPartOf
-#         range: dcat:Catalog
-#         description: This property refers to a related Catalogue in which the described Catalogue is physically or logically included.
-#         min: 0
-#         max: 1
-#       - name: record
-#         term: dcat:record
-#         range: dcat:CatalogRecord
-#         description: This property refers to a Catalogue Record that is part of the Catalogue
-#         min: 0
-#         max: n
-#       - name: Rights
-#         term: dct:rights
-#         range: dct:RightsStatement
-#         description: This property refers to a statement that specifies rights associated with the Catalogue.
-#         min: 0
-#         max: 1
-#       - name: service 
-#         term: dcat:service
-#         range: dcat:DataService
-#         description: This property refers to a site or end-point that is listed in the catalog.
-#         min: 0
-#         max: n
-#       - name: catalogue 
-#         term: dcat:catalog
-#         range: dcat:Catalog
-#         description: This property refers to a catalog whose contents are of interest in the context of this catalog
-#         min: 0
-#         max: n
-#       - name: creator
-#         term: dct:creator
-#         range: foaf:Agent
-#         description: This property refers to the  entity primarily responsible for producing the catalogue
-#         min: 0
-#         max: 1
 
   - title: Dataset
     description: A conceptual entity that represents the information published. 
@@ -223,126 +151,30 @@ classes:
           description: This property refers to information that indicates whether the Dataset is open data, has access restrictions or is not public. A controlled vocabulary with three members (:public, :restricted, :non-public) will be created and maintained by the Publications Office of the EU. 
           min: 0
           max: 1
-        #- name: creator
-          #term: dct:creator
-          #range: foaf:Agent
-          #description: This property refers to the  entity primarily responsible for producing the dataset
-          #min: 0
-          #max: 1
-        #- name: conforms to
-          #term: dct:conformsTo
-          #range: dct:Standard
-          #description: This property refers to an implementing rule or other specification.
-          #min: 0
-          #max: n
-        #- name: documentation
-          #term: foaf:page
-          #range: foaf:Document
-          #description: This property refers to a page or document about this Dataset.
-          #min: 0
-          #max: n
         - name: frequency
           term: dct:accrualPeriodicity
           range: dct:Frequency
           description: This property refers to the frequency at which the Dataset is updated.
           min: 0
           max: 1
-        #- name: has version
-          #term: dct:hasVersion
-          #range: dcat:Dataset
-          #description: This property refers to a related Dataset that is a version, edition, or adaptation of the described Dataset.
-          #min: 0
-          #max: n
         - name: identifier
           term: dct:identifier
           range: rdfs:Literal
           description: This property contains the main identifier for the Dataset, e.g. the URI or other unique identifier in the context of the Catalogue.
           min: 0
           max: n
-        #- name: is referenced by
-          #term: dct:isReferencedBy
-          #range: rdfs:Resource
-          #description: This property provides a link to a description of a relationship with another resource
-          #min: 0
-          #max: n
-        #- name: is version of
-          #term: dct:isVersionOf
-          #range: dcat:Dataset
-          #description: This property refers to a related Dataset of which the described Dataset is a version, edition, or adaptation.
-          #min: 0
-          #max: n
         - name: landing page
           term: dcat:landingPage
           range: foaf:Document
           description: This property refers to a web page that provides access to the Dataset, its Distributions and/or additional information. It is intended to point to a landing page at the original data provider, not to a page on a site of a third party, such as an aggregator.
           min: 0
           max: n
-        #- name: language
-          #term: dct:language
-          #range: dct:LinguisticSystem
-          #description: This property refers to a language of the Dataset. This property can be repeated if there are multiple languages in the Dataset.
-          #min: 0
-          #max: n
-        #- name: other identifier
-          #term: adms:identifier
-          #range: adms:Identifier
-          #description: This property refers to a secondary identifier of the Dataset, such as MAST/ADS1, DataCite2, DOI3, EZID4 or W3ID5.
-          #min: 0
-          #max: n
-        #- name: provenance
-          #term: dct:provenance
-          #range: dct:ProvenanceStatement
-          #description: This property contains a statement about the lineage of a Dataset.
-          #min: 0
-          #max: n
-        #- name: qualified attribution 
-          #term: prov:qualifiedAttribution 
-          #range: prov:Attribution
-          #description: This property refers to a liink to an Agent having some form of responsibility for the resource
-          #min: 0
-          #max: n
-        #- name: qualified relation
-          #term: dcat:qualifiedRelation
-          #range: dcat:Relationship
-          #description: This property is about a  related resource, such as a publication, that references, cites, or otherwise points to the dataset.
-          #min: 0
-          #max: n
-        #- name: related resource
-          #term: dct:relation
-          #range: rdfs:Resource
-          #description: This property refers to a related resource.
-          #min: 0
-          #max: n
         - name: release date
           term: dct:issued
           range: rdfs:Literal typed as xsd:date or xsd:dateTime
           description: This property contains the date of formal issuance (e.g., publication) of the Dataset.
           min: 0
           max: 1
-        #- name: sample
-          #term: adms:sample
-          #range: dcat:Distribution
-          #description: This property refers to a sample distribution of the dataset
-          #min: 0
-          #max: n
-        #- name: source
-          #term: dct:source
-          #range: dcat:Dataset
-          #description: This property refers to a related Dataset from which the described Dataset is derived.
-          #min: 0
-          #max: n
-        #- name: spatial resolution
-          #term: dcat:spatialResolutionInMeters
-          #range: xsd:decimal
-          #description: This property refers to the minimum spatial separation resolvable in a dataset, measured in meters.
-          #min: 0
-          #max: n
-        #- name: temporal resolution
-          #term: dcat:temporalResolution
-          #range: xsd:duration
-          #description: This property refers to the minimum time period resolvable in the dataset.
-          #min: 0
-          #max: n
         - name: type
           term: dct:type
           range: skos:Concept
@@ -355,30 +187,6 @@ classes:
           description: This property contains the most recent date on which the Dataset was changed or modified.
           min: 0
           max: 1
-        #- name: version
-          #term: owl:versionInfo
-          #range: rdfs:Literal
-          #description: This property contains a version number or other version designation of the Dataset.
-          #min: 0
-          #max: 1
-        #- name: version notes
-          #term: adms:versionNotes
-          #range: rdfs:Literal
-          #description: This property contains a description of the differences between this version and a previous version of the Dataset. This property can be repeated for parallel language versions of the version notes.
-          #min: 0
-          #max: n
-        #- name: was generated by
-          #term: prov:wasGeneratedBy
-          #range: prov:Activity
-          #description: This property refers to an activity that generated, or provides the business context for, the creation of the dataset.
-          #min: 0
-          #max: n
-        #- name: custodian
-          #term: geodcat:custodian
-          #range: foaf:Agent
-          #description: Party that accepts accountability and responsibility for the data and ensures appropriate care and maintenance of the resource [ISO-19115].
-          #min: 0
-          #max: n
         - name: HVD category
           term: dcatap:hvdCategory
           range: skos:Concept
@@ -406,12 +214,6 @@ classes:
           max: n
 
       recommended:
-        #- name: availability
-          #term: dcatap:availability
-          #range: skos:Concept
-          #description: This property indicates how long it is planned to keep the Distribution of the Dataset available. 
-          #min: 0
-          #max: 1
         - name: description
           term: dct:description
           range: rdfs:Literal
@@ -432,72 +234,24 @@ classes:
           max: 1
 
       optional:
-        #- name: access service 
-          #term: dcat:accessService
-          #range: dcat:DataService
-          #description: This property refers to a data service that gives access to the distribution of the dataset
-          #min: 0
-          #max: n
         - name: byte size
           term: dcat:byteSize
           range: rdfs:Literal typed as xsd:decimal
           description: This property contains the size of a Distribution in bytes.
           min: 0
           max: 1
-        #- name: Checksum
-          #term: spdx:checksum
-          #range: spdx:Checksum
-          #description: This property provides a mechanism that can be used to verify that the contents of a distribution have not changed. The checksum is related to the downloadURL.
-          #min: 0
-          #max: 1
-        #- name: compression format
-          #term: dcat:compressFormat
-          #range: dct:MediaType
-          #description: This property refers to the format of the file in which the data is contained in a compressed form, e.g. to reduce the size of the downloadable file. It SHOULD be expressed using a media type as defined in the official register of media types managed by IANA.
-          #min: 0
-          #max: 1
-        #- name: Documentation
-          #term: foaf:page
-          #range: foaf:Document
-          #description: This property refers to a page or document about this Distribution.
-          #min: 0
-          #max: n
         - name: download URL
           term: dcat:downloadURL
           range: rdfs:Resource
           description: This property contains a URL that is a direct link to a downloadable file in a given format. 
           min: 0
           max: n
-        #- name: has policy
-          #term: odrl:hasPolicy
-          #range: odrl:Policy
-          #description: This property refers to the policy expressing the rights associated with the distribution if using the ODRL vocabulary
-          #min: 0
-          #max: 1
-        #- name: Language
-          #term: dct:language
-          #range: dct:LinguisticSystem
-          #description: This property refers to a language used in the Distribution. This property can be repeated if the metadata is provided in multiple languages.
-          #min: 0
-          #max: n
         - name: linked schemas
           term: dct:conformsTo
           range: dct:Standard
           description: This property refers to an established schema to which the described Distribution conforms.
           min: 0
           max: n
-        #- name: media type
-          #term: dcat:mediaType, subproperty of dct:format
-          #range: dct:MediaType
-          #description: This property refers to the media type of the Distribution as defined in the official register of media types managed by IANA.
-          #min: 0
-          #max: 1
-        #- name: packaging format
-          #term: dcat:packageFormat
-          #range: dct:MediaType
-          #description: This property refers to the format of the file in which one or more data files are grouped together, e.g. to enable a set of related files to be downloaded together. It SHOULD be expressed using a media type as defined in the official register of media types managed by IANA.
-          #min: 0
-          #max: 1
         - name: release date
           term: dct:issued
           range: rdfs:Literal typed as xsd:date or xsd:dateTime
@@ -547,12 +301,6 @@ classes:
           description: This property contains the most recent date on which the Distribution was changed or modified.
           min: 0
           max: 1
-        #- name: Geographical accuracy
-          #term: dcat:spatialResolutionInMeters
-          #range: rdfs:Literal typed as xsd:decimal
-          #description: This property tells the accuracy of geospatial data in meters
-          #min: 0
-          #max: 1
         - name: applicable legislation
           term: dcatap:applicableLegislation
           range: hvd:LegalResource
@@ -560,10 +308,3 @@ classes:
           min: 0
           max: n
 
-# - title: placeholder
-#   description: placeholder
-#   term: placeholder
-#   properties:
-#     mandatory: []
-#     recommended: []
-#     optional: []

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/doc/dcat-ap/model.yml
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/doc/dcat-ap/model.yml
@@ -35,6 +35,8 @@ vocabularies:
     uri: "http://data.europa.eu/930/#"
   - prefix: gsp
     uri: "http://www.opengis.net/ont/geosparql#"
+  - prefix: hvd
+    uri: "https://semiceu.github.io/uri.semic.eu-generated/DCAT-AP/releases/2.2.0-hvd/#"
 classes:
   - title: Catalogue
     description: A catalogue or repository that hosts the Datasets being described.
@@ -377,6 +379,18 @@ classes:
           #description: Party that accepts accountability and responsibility for the data and ensures appropriate care and maintenance of the resource [ISO-19115].
           #min: 0
           #max: n
+        - name: HVD category
+          term: dcatap:hvdCategory
+          range: skos:Concept
+          description: The HVD category to which this Dataset belongs. 
+          min: 0
+          max: n
+        - name: applicable legislation
+          term: dcatap:applicableLegislation
+          range: hvd:LegalResource
+          description: The legislation that mandates the creation or management of the Dataset.
+          min: 0
+          max: n
 
 
   - title: Distribution
@@ -539,6 +553,12 @@ classes:
           #description: This property tells the accuracy of geospatial data in meters
           #min: 0
           #max: 1
+        - name: applicable legislation
+          term: dcatap:applicableLegislation
+          range: hvd:LegalResource
+          description: The legislation that mandates the creation or management of the Dataset.
+          min: 0
+          max: n
 
 # - title: placeholder
 #   description: placeholder

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/doc/dcat-ap/model.yml
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/doc/dcat-ap/model.yml
@@ -78,79 +78,79 @@ classes:
           description: This property refers to a language used in the textual metadata describing titles, descriptions, etc. of the Datasets in the Catalogue. This property can be repeated if the metadata is provided in multiple languages.
           min: 0
           max: n
-        - name: licence
-          term: dct:license
-          range: dct:LicenseDocument
-          description: This property refers to the licence under which the Catalogue can be used or reused.
-          min: 0
-          max: 1
-        - name: release date
-          term: dct:issued
-          range: rdfs:Literal typed as xsd:date or xsd:dateTime
-          description: This property contains the date of formal issuance (e.g., publication) of the Catalogue.
-          min: 0
-          max: 1
-        - name: spatial/ geographic
-          term: dct:spatial
-          range: dct:Location
-          description: This property refers to a geographical area covered by the Catalogue. 
-          min: 0
-          max: n
-        - name: themes
-          term: dcat:themeTaxonomy
-          range: skos:ConceptScheme
-          description: This property refers to a knowledge organization system used to classify the Catalogue's Datasets.
-          min: 0
-          max: n
-        - name: update/ modification date
-          term: dct:modified
-          range: rdfs:Literal typed as xsd:date or xsd:dateTime
-          description: This property contains the most recent date on which the Catalogue was modified.
-          min: 0
-          max: 1
-      optional:
-        - name: has part
-          term: dct:hasPart
-          range: dcat:Catalog
-          description: This property refers to a related Catalogue that is part of the described Catalogue
-          min: 0
-          max: n
-        - name: is part of
-          term: dct:isPartOf
-          range: dcat:Catalog
-          description: This property refers to a related Catalogue in which the described Catalogue is physically or logically included.
-          min: 0
-          max: 1
-        - name: record
-          term: dcat:record
-          range: dcat:CatalogRecord
-          description: This property refers to a Catalogue Record that is part of the Catalogue
-          min: 0
-          max: n
-        - name: Rights
-          term: dct:rights
-          range: dct:RightsStatement
-          description: This property refers to a statement that specifies rights associated with the Catalogue.
-          min: 0
-          max: 1
-        - name: service 
-          term: dcat:service
-          range: dcat:DataService
-          description: This property refers to a site or end-point that is listed in the catalog.
-          min: 0
-          max: n
-        - name: catalogue 
-          term: dcat:catalog
-          range: dcat:Catalog
-          description: This property refers to a catalog whose contents are of interest in the context of this catalog
-          min: 0
-          max: n
-        - name: creator
-          term: dct:creator
-          range: foaf:Agent
-          description: This property refers to the  entity primarily responsible for producing the catalogue
-          min: 0
-          max: 1
+#       - name: licence
+#         term: dct:license
+#         range: dct:LicenseDocument
+#         description: This property refers to the licence under which the Catalogue can be used or reused.
+#         min: 0
+#         max: 1
+#       - name: release date
+#         term: dct:issued
+#         range: rdfs:Literal typed as xsd:date or xsd:dateTime
+#         description: This property contains the date of formal issuance (e.g., publication) of the Catalogue.
+#         min: 0
+#         max: 1
+#       - name: spatial/ geographic
+#         term: dct:spatial
+#         range: dct:Location
+#         description: This property refers to a geographical area covered by the Catalogue. 
+#         min: 0
+#         max: n
+#       - name: themes
+#         term: dcat:themeTaxonomy
+#         range: skos:ConceptScheme
+#         description: This property refers to a knowledge organization system used to classify the Catalogue's Datasets.
+#         min: 0
+#         max: n
+#       - name: update/ modification date
+#         term: dct:modified
+#         range: rdfs:Literal typed as xsd:date or xsd:dateTime
+#         description: This property contains the most recent date on which the Catalogue was modified.
+#         min: 0
+#         max: 1
+      optional: []
+#       - name: has part
+#         term: dct:hasPart
+#         range: dcat:Catalog
+#         description: This property refers to a related Catalogue that is part of the described Catalogue
+#         min: 0
+#         max: n
+#       - name: is part of
+#         term: dct:isPartOf
+#         range: dcat:Catalog
+#         description: This property refers to a related Catalogue in which the described Catalogue is physically or logically included.
+#         min: 0
+#         max: 1
+#       - name: record
+#         term: dcat:record
+#         range: dcat:CatalogRecord
+#         description: This property refers to a Catalogue Record that is part of the Catalogue
+#         min: 0
+#         max: n
+#       - name: Rights
+#         term: dct:rights
+#         range: dct:RightsStatement
+#         description: This property refers to a statement that specifies rights associated with the Catalogue.
+#         min: 0
+#         max: 1
+#       - name: service 
+#         term: dcat:service
+#         range: dcat:DataService
+#         description: This property refers to a site or end-point that is listed in the catalog.
+#         min: 0
+#         max: n
+#       - name: catalogue 
+#         term: dcat:catalog
+#         range: dcat:Catalog
+#         description: This property refers to a catalog whose contents are of interest in the context of this catalog
+#         min: 0
+#         max: n
+#       - name: creator
+#         term: dct:creator
+#         range: foaf:Agent
+#         description: This property refers to the  entity primarily responsible for producing the catalogue
+#         min: 0
+#         max: 1
 
   - title: Dataset
     description: A conceptual entity that represents the information published. 

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/doc/dcat-ap/template.html.j2
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/doc/dcat-ap/template.html.j2
@@ -37,7 +37,7 @@
     {% for class in classes %}
     <h3 id="{{ class.term }}">{{ class.term }}</h3>
     
-    {% if class.subclassOf %}
+    {% if 'subclassOf' in class %}
       <p>Sub-class of {{ class.subclassOf }}</p>
     {% endif -%}
 
@@ -49,22 +49,24 @@
     <h4>Properties</h4>
 
     {% for level in ['mandatory', 'recommended', 'optional'] %}
-    <table class="table table-striped">
-      <caption>{{ level | title }} properties</caption>
-      <thead>
-        <tr><th>Term</th><th>Range</th><th>Cardinality</th><th>Comment</th></tr>
-      </thead>
-      <tbody>
-      {% for property in class.properties[level] -%}
-        <tr>
-          <td>{% if property.extension %}<strong>{{ property.term }}</strong>{% else %}{{ property.term }} {% endif -%}</td>
-          <td>{{ property.range }}</td>
-          <td>{{ property.min }}..{{ property.max }}</td>
-          <td>{{ property.description }}</td>
-        </tr>
-      {% endfor %} {# property #}
-      </tbody>
-    </table>
+      {% if level in class.properties and class.properties[level] %}
+      <table class="table table-striped">
+        <caption>{{ level | title }} properties</caption>
+        <thead>
+          <tr><th>Term</th><th>Range</th><th>Cardinality</th><th>Comment</th></tr>
+        </thead>
+        <tbody>
+        {% for property in class.properties[level] -%}
+          <tr>
+            <td>{% if 'extension' in property %}<strong>{{ property.term }}</strong>{% else %}{{ property.term }} {% endif -%}</td>
+            <td>{{ property.range }}</td>
+            <td>{{ property.min }}..{{ property.max }}</td>
+            <td>{{ property.description }}</td>
+          </tr>
+        {% endfor %} {# property #}
+        </tbody>
+      </table>
+      {% endif %}
     {% endfor %} {# level #}
     {% endfor %} {# class #}
 

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/doc/dcat-ap/template.md.j2
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/doc/dcat-ap/template.md.j2
@@ -24,7 +24,7 @@ Prefix | URI
 {% for class in classes %}
 ### {{ class.term }}
 
-{% if class.subclassOf %}
+{% if 'subclassOf' in class %}
   Sub-class of {{ class.subclassOf }}
 {% endif -%}
 
@@ -35,12 +35,14 @@ Prefix | URI
 #### Properties
 
 {% for level in ['mandatory', 'recommended', 'optional'] %}
+{% if level in class.properties and class.properties[level] %}
 ##### {{ level | title }}
 Term | Range | Cardinality | Comment
 -----|-------|-------------|--------
 {% for property in class.properties[level] -%}
-  {% if property.extension %}**{{ property.term }}** {% else %}{{ property.term }} {% endif -%}
+  {% if 'extension' in property %}**{{ property.term }}** {% else %}{{ property.term }} {% endif -%}
   | {{ property.range }} | {{ property.min }}..{{ property.max }} | {{ property.description }}
 {% endfor %} {# property #}
+{% endif %}
 {% endfor %} {# level #}
 {% endfor %} {# class #}


### PR DESCRIPTION
- Remove unused properties
- Add required HVD properties
  - `dcatap:hvdCategory` is `0..*` cardinality even though [the spec](https://semiceu.github.io/uri.semic.eu-generated/DCAT-AP/releases/2.2.0-hvd/#Dataset) requires `1..*` since only some of our datasets are HVD
  - `dcatap:applicableLegislation` added since a specific value in it is required by the spec, but at `0..*` cardinality for the same reason as above