### PR TITLE
REKDAT-166: Translate category names and descriptions

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/helpers.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/helpers.py
@@ -4,6 +4,7 @@ from ckan.plugins import toolkit
 from ckan.lib import i18n
 from ckanext.scheming.helpers import lang
 from ckan.logic import NotFound
+from flask import has_request_context
 from logging import getLogger
 from datetime import datetime, timedelta
 import iso8601
@@ -280,13 +281,19 @@ def get_highvalue_category_label(value):
     return highvalue_categories.get(value, "")
 
 def get_group_title_translations():
-    context = {'model': model, 'session': model.Session, 'user': c.user}
+    context = {'model': model, 'session': model.Session}
+    if has_request_context() and toolkit.g.get('user'):
+        context['user'] = toolkit.g.user
+
     data_dict = {'all_fields': True, 'include_extras': True, 'include_dataset_count': False}
     groups = toolkit.get_action('group_list')(context, data_dict)
     return {g['name']: g.get('title_translated', {}) for g in groups}
 
 def get_translated_groups(groups):
-    context = {'model': model, 'session': model.Session, 'user': c.user}
+    context = {'model': model, 'session': model.Session}
+    if has_request_context() and toolkit.g.get('user'):
+        context['user'] = toolkit.g.user
+
     data_dict = {'groups': [g['name'] for g in groups],
                  'all_fields': True,
                  'include_extras': True,

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/helpers.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/helpers.py
@@ -278,3 +278,17 @@ def scheming_highvalue_category_list(field):
 
 def get_highvalue_category_label(value):
     return highvalue_categories.get(value, "")
+
+def get_group_title_translations():
+    context = {'model': model, 'session': model.Session, 'user': c.user}
+    data_dict = {'all_fields': True, 'include_extras': True, 'include_dataset_count': False}
+    groups = toolkit.get_action('group_list')(context, data_dict)
+    return {g['name']: g.get('title_translated', {}) for g in groups}
+
+def get_translated_groups(groups):
+    context = {'model': model, 'session': model.Session, 'user': c.user}
+    data_dict = {'groups': [g['name'] for g in groups],
+                 'all_fields': True,
+                 'include_extras': True,
+                 'include_dataset_count': False}
+    return toolkit.get_action('group_list')(context, data_dict)

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
@@ -74,7 +74,9 @@ class RestrictedDataPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'get_translated_logo': helpers.get_translated_logo,
             'get_assignable_groups_for_package': helpers.get_assignable_groups_for_package,
             'scheming_highvalue_category_list': helpers.scheming_highvalue_category_list,
-            'get_highvalue_category_label': helpers.get_highvalue_category_label
+            'get_highvalue_category_label': helpers.get_highvalue_category_label,
+            'get_group_title_translations': helpers.get_group_title_translations,
+            'get_translated_groups': helpers.get_translated_groups
         }
 
     # IValidators:
@@ -102,12 +104,18 @@ class RestrictedDataPlugin(plugins.SingletonPlugin, DefaultTranslation):
     def after_dataset_search(self, search_results, search_params) -> PackageDict:
 
         # Modify facet display name to be human-readable
-        # TODO: handle translations for groups and highvalue categories
+        group_titles = helpers.get_group_title_translations()
+        lang = helpers.get_lang_prefix()
+        # TODO: handle translations for highvalue categories
         if search_results.get('search_facets'):
             for facet in search_results['search_facets']:
                 if facet == "vocab_highvalue_category":
                     for facet_item in search_results['search_facets'][facet]['items']:
                         facet_item['display_name'] = helpers.get_highvalue_category_label(facet_item['name'])
+                elif facet == "groups":
+                    for facet_item in search_results['search_facets'][facet]['items']:
+                        facet_item['display_name'] = (group_titles.get(facet_item['name'], {})
+                                                      .get(lang, facet_item['display_name']))
 
 
         # Only filter results if processing a request

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
@@ -105,7 +105,7 @@ class RestrictedDataPlugin(plugins.SingletonPlugin, DefaultTranslation):
 
         # Modify facet display name to be human-readable
         group_titles = helpers.get_group_title_translations()
-        lang = helpers.get_lang_prefix()
+        lang = helpers.get_lang_prefix() if has_request_context() else toolkit.config.get('ckan_locale_default', 'en')
         # TODO: handle translations for highvalue categories
         if search_results.get('search_facets'):
             for facet in search_results['search_facets']:

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/group/read_base.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/group/read_base.html
@@ -1,0 +1,7 @@
+{% ckan_extends %}
+
+{% block breadcrumb_content %}
+  {% set title = h.get_translated(group_dict, 'title') %}
+  <li>{% link_for h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups'), named_route=group_type+'.index' %}</li>
+  <li class="active">{% link_for title|truncate(35), named_route=group_type+'.read', id=group_dict.name, title=title %}</li>
+{% endblock %}

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/group/snippets/group_item.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/group/snippets/group_item.html
@@ -4,11 +4,13 @@
     <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ group.name }}" class="media-image img-fluid">
   {% endblock %}
   {% block title %}
-    <h2 class="media-heading">{{ group.display_name }}</h2>
+    {% set title = h.get_translated(group, 'title') %}
+    <h2 class="media-heading">{{ title }}</h2>
   {% endblock %}
   {% block description %}
-    {% if group.description %}
-      <p class="media-description">{{ h.markdown_extract(group.description, extract_length=80) }}</p>
+    {% set description = h.get_translated(group, 'description') %}
+    {% if description %}
+      <p class="media-description">{{ h.markdown_extract(description, extract_length=80) }}</p>
     {% endif %}
   {% endblock %}
   {% block datasets %}

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/group/snippets/info.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/group/snippets/info.html
@@ -1,0 +1,23 @@
+{% ckan_extends %}
+
+{% block heading %}
+<h1 class="heading">
+  {% set title = h.get_translated(group, 'title') %}
+  {{ title }}
+  {% if group.state == 'deleted' %}
+    [{{ _('Deleted') }}]
+  {% endif %}
+</h1>
+{% endblock %}
+
+{% block description %}
+{% set description = h.get_translated(group, 'description') %}
+{% if description %}
+  <p class="description">
+    {{ h.markdown_extract(description, 180) }}
+  </p>
+  <p class="read-more">
+    {% link_for _('read more'), named_route='group.about', id=group.name %}
+  </p>
+{% endif %}
+{% endblock %}

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/package/group_list.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/package/group_list.html
@@ -20,8 +20,9 @@
   {% if pkg_dict.groups %}
     <form method="post">
       {{ h.csrf_input() }}
+      {% set translated_groups = h.get_translated_groups(pkg_dict.groups) %}
       {% set allow_group_delete = h.check_access('package_update', {'id': pkg.id }) %}
-      {% snippet 'group/snippets/group_list.html', groups=pkg_dict.groups, allow_delete=allow_group_delete %}
+      {% snippet 'group/snippets/group_list.html', groups=translated_groups, allow_delete=allow_group_delete %}
     </form>
   {% else %}
     <p class="empty">{{ h.humanize_entity_type('group', default_group_type, 'no associated label') or _('There are no groups associated with this dataset') }}</p>

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/package/snippets/categories.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/package/snippets/categories.html
@@ -4,6 +4,7 @@
   {% if categories %}
     {% block category_list %}
       <ul class="categories__list">
+        {% set category_titles = h.get_group_title_translations() %}
         {% for category in categories %}
           {% set item_classes = ["categories__list__item"] %}
           {% if loop.index > 3 %}
@@ -13,8 +14,8 @@
             <img class="categories__list__item__icon"
                  src="{{ category.get('image_display_url') }}"
                  alt="{{- _('Category icon') -}}" />
-            {% if category.get('title_translated', {}).get(lang) %}
-              <h5 class="categories__list__item__title">{% link_for category.get('title_translated', {}).get(lang), named_route='group_read', id=category.get('name') %}</h5>
+            {% if category_titles.get(category.name, {}).get(lang) %}
+              <h5 class="categories__list__item__title">{% link_for category_titles.get(category.name, {}).get(lang), named_route='group_read', id=category.get('name') %}</h5>
             {% else %}
               <h5 class="categories__list__item__title">{% link_for category.get('display_name'), named_route='group_read', id=category.get('name') %}</h5>
             {% endif %}

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_helpers.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_helpers.py
@@ -42,7 +42,7 @@ class TestGetAssignableGroupsForPackageHelper(object):
 
 
 @pytest.mark.usefixtures("clean_db", "with_plugins")
-def test_get_group_title_translations(app):
+def test_get_group_title_translations():
     titles = [(lang, f'title {lang}') for lang in ['fi', 'sv', 'en']]
     g = Group(title_translated=dict(titles))
     name = g['name']
@@ -52,8 +52,8 @@ def test_get_group_title_translations(app):
         assert group_titles[name][lang] == title
 
 
-@pytest.mark.usefixtures("clean_db", "with_plugins", "with_request_context")
-def test_get_translated_groups(app):
+@pytest.mark.usefixtures("clean_db", "with_plugins")
+def test_get_translated_groups():
     titles = [(lang, f'title {lang}') for lang in ['fi', 'sv', 'en']]
     g = Group(title_translated=dict(titles))
     del g['title_translated']

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_helpers.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_helpers.py
@@ -3,16 +3,15 @@ import pytest
 # import ckanext.restricteddata.plugin as plugin
 from ckan.plugins import toolkit
 from ckan.tests.factories import Dataset, Sysadmin, Organization, User, Group
-from .utils import minimal_dataset_with_one_resource_fields
+from .utils import minimal_dataset_with_one_resource_fields, minimal_group
 
 import ckanext.restricteddata.helpers as helpers
-
 
 @pytest.mark.usefixtures("clean_db", "with_plugins")
 class TestGetAssignableGroupsForPackageHelper(object):
     @pytest.mark.usefixtures("with_request_context")
     def test_get_assignable_groups_for_package_helper_with_non_maintainer(self, app):
-        _g = Group()
+        _g = Group(**minimal_group())
         some_user = User()
         org = Organization()
 
@@ -26,8 +25,8 @@ class TestGetAssignableGroupsForPackageHelper(object):
 
     @pytest.mark.usefixtures("with_request_context")
     def test_get_assignable_groups_for_package_helper_with_maintainer(self, app):
-        g1 = Group()
-        g2 = Group()
+        g1 = Group(**minimal_group())
+        g2 = Group(**minimal_group())
         maintainer = User()
         org = Organization(user=maintainer)
 

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_helpers.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_helpers.py
@@ -40,3 +40,24 @@ class TestGetAssignableGroupsForPackageHelper(object):
         [unassigned_group] = helpers.get_assignable_groups_for_package(d)
         assert unassigned_group['name'] == g2['name']
 
+
+@pytest.mark.usefixtures("clean_db", "with_plugins")
+def test_get_group_title_translations(app):
+    titles = [(lang, f'title {lang}') for lang in ['fi', 'sv', 'en']]
+    g = Group(title_translated=dict(titles))
+    name = g['name']
+    group_titles = helpers.get_group_title_translations()
+
+    for lang, title in titles:
+        assert group_titles[name][lang] == title
+
+
+@pytest.mark.usefixtures("clean_db", "with_plugins", "with_request_context")
+def test_get_translated_groups(app):
+    titles = [(lang, f'title {lang}') for lang in ['fi', 'sv', 'en']]
+    g = Group(title_translated=dict(titles))
+    del g['title_translated']
+    [translated] = helpers.get_translated_groups([g])
+
+    for lang, title in titles:
+        assert translated['title_translated'][lang] == title

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
@@ -55,7 +55,7 @@ from ckan.plugins import plugin_loaded, toolkit
 from ckan.tests.factories import Dataset, Sysadmin, Organization, User, Group
 from ckan.tests.helpers import call_action
 from ckan.plugins.toolkit import NotAuthorized
-from .utils import minimal_dataset_with_one_resource_fields
+from .utils import minimal_dataset_with_one_resource_fields, minimal_group
 
 
 @pytest.mark.usefixtures("with_plugins")
@@ -379,7 +379,7 @@ def test_dataset_with_resource_with_geographical_accuracy():
 
 @pytest.mark.usefixtures("clean_db", "with_plugins")
 def test_maintainer_can_add_dataset_to_group(app):
-    g = Group()
+    g = Group(**minimal_group())
     author = User()
     org = Organization(user=author)
 
@@ -401,7 +401,7 @@ def test_maintainer_can_add_dataset_to_group(app):
 
 @pytest.mark.usefixtures("clean_db", "with_plugins")
 def test_non_maintainer_can_not_add_dataset_to_group(app):
-    g = Group()
+    g = Group(**minimal_group())
     some_user = User()
     org = Organization()
 
@@ -420,7 +420,7 @@ def test_non_maintainer_can_not_add_dataset_to_group(app):
 
 @pytest.mark.usefixtures("clean_db", "with_plugins")
 def test_categories_are_added_as_groups(app):
-    g = Group()
+    g = Group(**minimal_group())
     dataset_fields = minimal_dataset_with_one_resource_fields(Sysadmin())
     dataset_fields['categories'] = g['name']
     d = Dataset(**dataset_fields)
@@ -431,7 +431,7 @@ def test_categories_are_added_as_groups(app):
 
 @pytest.mark.usefixtures("clean_db", "with_plugins")
 def test_groups_are_removed_when_categories_are_removed(app):
-    g = Group()
+    g = Group(**minimal_group())
     dataset_fields = minimal_dataset_with_one_resource_fields(Sysadmin())
 
     d = Dataset(**dataset_fields)

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
@@ -187,6 +187,30 @@ def test_search_facets_with_highvalue_category():
     }
 
 
+@pytest.mark.usefixtures("clean_db", "clean_index", "with_plugins")
+def test_search_facets_with_category():
+    category = Group(**minimal_group())
+    dataset_fields = minimal_dataset_with_one_resource_fields(Sysadmin())
+    dataset_fields['categories'] = [category['name']]
+    Dataset(**dataset_fields)
+    data_dict = {
+        "facet.field": ['groups']
+    }
+    results = call_action('package_search', **data_dict )
+    assert results['search_facets'] == {
+        "groups": {
+            "items": [
+                {
+                    "count": 1,
+                    "display_name": category['display_name'],
+                    "name": category['name']
+                }
+            ],
+            "title": "groups"
+        }
+    }
+
+
 @pytest.mark.usefixtures("clean_db", "with_plugins")
 def test_dataset_with_external_ursl():
     dataset_fields = minimal_dataset_with_one_resource_fields(Sysadmin())

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/utils.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/utils.py
@@ -19,3 +19,7 @@ def minimal_dataset_with_one_resource_fields(user):
     )
 
 
+def minimal_group():
+    return dict(
+        title_translated={lang: f'title {lang}' for lang in ['fi', 'sv']}
+    )

--- a/ckan/ckanext/ckanext-restricteddata/test.ini
+++ b/ckan/ckanext/ckanext-restricteddata/test.ini
@@ -8,9 +8,11 @@ use = config:../ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here. These will override the one defined in CKAN core's test-core.ini
-ckan.plugins = scheming_datasets fluent restricteddata_pages pages restricteddata markdown_editor dcat restricteddata_paha_authentication
+ckan.plugins = scheming_datasets scheming_groups fluent restricteddata_pages pages restricteddata markdown_editor dcat restricteddata_paha_authentication
 
 scheming.dataset_schemas = ckanext.restricteddata.schemas:dataset.json
+scheming.group_schemas = ckanext.restricteddata.schemas:group.json
+
 scheming.presets = ckanext.scheming:presets.json
 				   ckanext.fluent:presets.json
 				   ckanext.restricteddata:presets.json


### PR DESCRIPTION
- Add helpers for translating group titles or group objects
- Translate group titles in search facets
- Translate group titles and descriptions in group lists
- Translate group titles and descriptions in group view
- Translate category titles and descriptions in dataset categories