### PR TITLE
REKDAT-190: Disable creating default categories

### DIFF
--- a/ckan/scripts/init_ckan.sh
+++ b/ckan/scripts/init_ckan.sh
@@ -30,8 +30,5 @@ if [[ "${MATOMO_ENABLED}" == "true" ]]; then
   ckan -c ${APP_DIR}/ckan.ini matomo init_db && ckan -c ${APP_DIR}/ckan.ini db upgrade -p matomo
 fi
 
-echo "Create default restricteddata categories ..."
-ckan -c ${APP_DIR}/ckan.ini restricteddata create-default-categories
-
 # set init flag to done
 echo "$CKAN_IMAGE_TAG" > ${DATA_DIR}/.init-done


### PR DESCRIPTION
Default categories can still be created from command line, but its not automatic due to the maintaining them.