### PR TITLE
REKDAT-175: Limit create api tokens to sysadmins

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/auth.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/auth.py
@@ -21,3 +21,7 @@ def member_delete(next_auth, context, data_dict):
                     'message': 'Only dataset owners can modify dataset groups'}
 
     return next_auth(context, data_dict)
+
+
+def sysadmin_only(contaxt, data_dict):
+    return {'success': False, 'message': 'Only sysadmins are allowed to call this'}

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
@@ -214,6 +214,7 @@ class RestrictedDataPlugin(plugins.SingletonPlugin, DefaultTranslation):
         return {
             'member_create': auth.member_create,
             'member_delete': auth.member_delete,
+            'api_token_create': auth.sysadmin_only
         }
 
 

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
@@ -535,3 +535,15 @@ def test_paha_authentication_logs_in_user(app):
     response = client.get(toolkit.url_for("user.read", id=some_user['name']))
     assert response.status_code == 200
     assert some_user['email'] in response.body
+
+@pytest.mark.usefixtures("clean_db", "with_plugins")
+def test_only_sysadmin_can_create_api_tokens():
+    u = User()
+    context = {"user": u["name"], "ignore_auth": False}
+    with pytest.raises(NotAuthorized):
+        call_action('api_token_create', context=context, user=u['name'], name="some api token name")
+
+    sysadmin = Sysadmin()
+    context = {"user": sysadmin["name"], "ignore_auth": False}
+    api_token = call_action('api_token_create', context=context, user=sysadmin['name'], name="some api token name")
+    assert api_token['token']


### PR DESCRIPTION
Limits create_api_token action to sysadmins only.