### PR TITLE
REKDAT-170: Limit user list to sysadmins

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/action.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/action.py
@@ -31,3 +31,13 @@ def member_roles_list(original_action, context, data_dict):
                   if role['value'] != 'member']
 
     return result
+
+
+@toolkit.chained_action
+def user_autocomplete(original_action, context, data_dict):
+    try:
+        toolkit.check_access('user_autocomplete', context, data_dict)
+    except toolkit.NotAuthorized:
+        return []
+
+    return original_action(context, data_dict)

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/auth.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/auth.py
@@ -21,3 +21,7 @@ def member_delete(next_auth, context, data_dict):
                     'message': 'Only dataset owners can modify dataset groups'}
 
     return next_auth(context, data_dict)
+
+
+def sysadmin_only(contaxt, data_dict):
+    return {'success': False, 'message': 'Only sysadmins are allowed to call this'}

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
@@ -206,6 +206,7 @@ class RestrictedDataPlugin(plugins.SingletonPlugin, DefaultTranslation):
         return {
             'user_create': action.user_create,
             'member_roles_list': action.member_roles_list,
+            'user_autocomplete': action.user_autocomplete
         }
 
     # IAuthFunctions
@@ -214,7 +215,8 @@ class RestrictedDataPlugin(plugins.SingletonPlugin, DefaultTranslation):
         return {
             'member_create': auth.member_create,
             'member_delete': auth.member_delete,
-            'api_token_create': auth.sysadmin_only
+            'api_token_create': auth.sysadmin_only,
+            'user_list': auth.sysadmin_only
         }
 
 

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
@@ -214,6 +214,7 @@ class RestrictedDataPlugin(plugins.SingletonPlugin, DefaultTranslation):
         return {
             'member_create': auth.member_create,
             'member_delete': auth.member_delete,
+            'api_token_create': auth.sysadmin_only
         }
 
 

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
@@ -535,3 +535,15 @@ def test_paha_authentication_logs_in_user(app):
     response = client.get(toolkit.url_for("user.read", id=some_user['name']))
     assert response.status_code == 200
     assert some_user['email'] in response.body
+
+@pytest.mark.usefixtures("clean_db", "with_plugins")
+def test_only_sysadmin_can_create_api_tokens():
+    u = User()
+    context = {"user": u["name"], "ignore_auth": False}
+    with pytest.raises(NotAuthorized):
+        call_action('api_token_create', context=context, user=u['name'], name="some api token name")
+
+    sysadmin = Sysadmin()
+    context = {"user": sysadmin["name"], "ignore_auth": False}
+    api_token = call_action('api_token_create', context=context, user=sysadmin['name'], name="some api token name")
+    assert api_token['token']

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
@@ -547,3 +547,25 @@ def test_only_sysadmin_can_create_api_tokens():
     context = {"user": sysadmin["name"], "ignore_auth": False}
     api_token = call_action('api_token_create', context=context, user=sysadmin['name'], name="some api token name")
     assert api_token['token']
+
+
+@pytest.mark.usefixtures("clean_db", "with_plugins")
+def test_normal_user_has_no_access_to_user_list():
+    u = User()
+    context = {"user": u["name"], "ignore_auth": False}
+    with pytest.raises(NotAuthorized):
+        call_action('user_list', context=context)
+
+    result = call_action('user_autocomplete', context=context, q=u['name'])
+    assert result == []
+
+
+@pytest.mark.usefixtures("clean_db", "with_plugins")
+def test_sysadmin_has_user_autocomplete():
+    u = User()
+    sysadmin = Sysadmin()
+    context = {"user": sysadmin["name"], "ignore_auth": False}
+
+    result = call_action('user_autocomplete', context=context, q=u['name'])
+    assert len(result) == 1
+    assert result[0]['name'] == u['name']


### PR DESCRIPTION
Built on top of #271 due to the sysadmin only auth function.

Limits user list to sysadmins and modified user_autocomplete to return empty list if auth fails.