### PR TITLE
REKDAT-184: Do not show organization fields that do not have display snippet

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/scheming/organization/about.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/scheming/organization/about.html
@@ -1,0 +1,16 @@
+{% ckan_extends %}
+
+{% if group_dict is not defined%}
+{% set group_dict = c.group_dict %}
+{% endif %}
+
+{% block primary_content_inner %}
+<dl>
+  {% for f in c.scheming_fields %}
+    {% if f.display_snippet is not none %}
+      <dt>{{ h.scheming_language_text(f.label) }}:</dt>
+      <dd>{{ group_dict[f.field_name] or ("&nbsp;"|safe) }}</dd>
+    {% endif %}
+  {% endfor %}
+</dl>
+{% endblock %}


### PR DESCRIPTION
Hides vat number field from organization about page.