### PR TITLE
Enable PAHA authentication plugin in CDK deployed environments

### DIFF
--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -77,6 +77,7 @@ export class CkanStack extends Stack {
       "restricteddata_pages",
       "pages",
       "restricteddata",
+      "restricteddata_paha_authentication",
       "markdown_editor",
       "activity",
       "text_view",


### PR DESCRIPTION
- `restricteddata_paha_authentication` plugin was only enabled in local environments, causing errors in cronjobs. Enable it also in CDK deployed environments