### PR TITLE
REKDAT-174: Reconfigure profile link route to dashboard

### DIFF
--- a/assets/src/scss/ckan/header.scss
+++ b/assets/src/scss/ckan/header.scss
@@ -161,7 +161,7 @@ header.masthead {
           display: flex;
         }
 
-        .logout {
+        .text {
           font-size: rd.$font-size-xxs;
         }
       }

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/i18n/ckanext-restricteddata.pot
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/i18n/ckanext-restricteddata.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-restricteddata 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-08-28 12:22+0000\n"
+"POT-Creation-Date: 2024-09-23 10:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.10.3\n"
 
-#: ckanext/restricteddata/plugin.py:191
+#: ckanext/restricteddata/plugin.py:193
 #: ckanext/restricteddata/templates/group/read_base.html:5
 #: ckanext/restricteddata/templates/package/group_list.html:4
 #: ckanext/restricteddata/templates/package/group_list.html:20
@@ -26,15 +26,15 @@ msgstr ""
 msgid "Groups"
 msgstr ""
 
-#: ckanext/restricteddata/plugin.py:192
+#: ckanext/restricteddata/plugin.py:194
 msgid "Tags"
 msgstr ""
 
-#: ckanext/restricteddata/plugin.py:193
+#: ckanext/restricteddata/plugin.py:195
 msgid "Format"
 msgstr ""
 
-#: ckanext/restricteddata/plugin.py:194 ckanext/restricteddata/translations.py:103
+#: ckanext/restricteddata/plugin.py:196 ckanext/restricteddata/translations.py:103
 msgid "High-value dataset category"
 msgstr ""
 
@@ -1001,43 +1001,48 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: ckanext/restricteddata/templates/header.html:54
 #: ckanext/restricteddata/templates/header.html:55
-msgid "Log out"
+#: ckanext/restricteddata/templates/header.html:56
+msgid "Sysadmin profile"
 msgstr ""
 
 #: ckanext/restricteddata/templates/header.html:59
+#: ckanext/restricteddata/templates/header.html:60
+msgid "Log out"
+msgstr ""
+
+#: ckanext/restricteddata/templates/header.html:64
 msgid "Account"
 msgstr ""
 
-#: ckanext/restricteddata/templates/header.html:63
-#: ckanext/restricteddata/templates/header.html:65
+#: ckanext/restricteddata/templates/header.html:68
+#: ckanext/restricteddata/templates/header.html:70
 msgid "Log in"
 msgstr ""
 
-#: ckanext/restricteddata/templates/header.html:98
+#: ckanext/restricteddata/templates/header.html:103
 #: ckanext/restricteddata/templates/snippets/home_breadcrumb_item.html:2
 msgid "Home"
 msgstr ""
 
-#: ckanext/restricteddata/templates/header.html:99
+#: ckanext/restricteddata/templates/header.html:104
 #: ckanext/restricteddata/templates/home/layout1.html:52
 #: ckanext/restricteddata/templates/package/search.html:11
 msgid "Datasets"
 msgstr ""
 
-#: ckanext/restricteddata/templates/header.html:102
+#: ckanext/restricteddata/templates/header.html:107
 #: ckanext/restricteddata/templates/home/layout1.html:64
 #: ckanext/restricteddata/templates/organization/index.html:4
 #: ckanext/restricteddata/templates/package/base.html:20
 msgid "Organizations"
 msgstr ""
 
-#: ckanext/restricteddata/templates/header.html:115
+#: ckanext/restricteddata/templates/header.html:120
 msgid "More options"
 msgstr ""
 
-#: ckanext/restricteddata/templates/header.html:131
+#: ckanext/restricteddata/templates/header.html:136
 msgid "Suomi.fi-avoindata"
 msgstr ""
 

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/header.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/header.html
@@ -49,7 +49,7 @@
     <div class="user">
       {% if c.userobj %}
       <div class="account authed" data-module="me" data-me="{{ c.userobj.id }}">
-        <a href="{{ h.url_for('user.read', id=c.userobj.name) }}" title="{{ _('View profile') }}">
+        <a href="{{ h.url_for('activity.dashboard')}}" title="{{ _('View profile') }}">
           <span class="username">{{ c.userobj.display_name }}</span></a>
         <a href="{{ h.url_for('user.logout') }}" class="logout" title="{{ _('Log out') }}">
           <span class="text">{{ _('Log out')|upper }}</span>

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/header.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/header.html
@@ -51,8 +51,13 @@
       <div class="account authed" data-module="me" data-me="{{ c.userobj.id }}">
         <a href="{{ h.url_for('activity.dashboard')}}" title="{{ _('View profile') }}">
           <span class="username">{{ c.userobj.display_name }}</span></a>
-        <a href="{{ h.url_for('user.logout') }}" class="logout" title="{{ _('Log out') }}">
-          <span class="text">{{ _('Log out')|upper }}</span>
+        {% if h.check_access('sysadmin') %}
+        <a href="{{ h.url_for('user.read', id=c.userobj.name) }}" class="text" title="{{ _('Sysadmin profile') }}">
+          <span>{{ _('Sysadmin profile') }}</span>
+        </a>
+        {% endif %}
+        <a href="{{ h.url_for('user.logout') }}"  class="text" title="{{ _('Log out') }}">
+          <span>{{ _('Log out')|upper }}</span>
         </a>
       </div>
       {% else %}

--- a/ckan/ckanext/ckanext-restricteddata/test.ini
+++ b/ckan/ckanext/ckanext-restricteddata/test.ini
@@ -8,7 +8,7 @@ use = config:../ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here. These will override the one defined in CKAN core's test-core.ini
-ckan.plugins = scheming_datasets scheming_groups scheming_organizations fluent restricteddata_pages pages restricteddata markdown_editor dcat restricteddata_paha_authentication
+ckan.plugins = scheming_datasets scheming_groups scheming_organizations fluent restricteddata_pages pages restricteddata markdown_editor dcat restricteddata_paha_authentication activity
 
 scheming.dataset_schemas = ckanext.restricteddata.schemas:dataset.json
 scheming.organization_schemas = ckanext.restricteddata.schemas:organization.json


### PR DESCRIPTION
`/dashboard` is under activity blueprint which is some what weird, but there it is anyway.