### PR TITLE
REKDAT-173: Login button navigates to PAHA login in non-development environments

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/header.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/header.html
@@ -60,7 +60,12 @@
         <ul class="list-unstyled">
           {% block header_account_notlogged %}
           <li>
-            <a href="{{ h.url_for('user.login') }}" class="btn btn-primary" title="{{ _('Log in') }}">
+            {% if g.debug %}
+              {% set login_url = h.url_for('user.login') %}
+            {% else %}
+              {% set login_url = "https://palveluhallinta.suomi.fi/" + current_lang + "/rekisteroityminen" %}
+            {% endif %}
+            <a href="{{ login_url }}" class="btn btn-primary" title="{{ _('Log in') }}">
               <i class="icon login"></i>
               <span class="text">{{ _('Log in') }}</span>
             </a>


### PR DESCRIPTION
- Set login button url to point to PAHA if the current environment is not a debug environment