### PR TITLE
REKDAT-179: sysadmin only member management

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/auth.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/auth.py
@@ -3,25 +3,33 @@ from ckan.types import Context, DataDict, AuthResult, AuthFunction
 
 @toolkit.chained_auth_function
 def member_create(next_auth: AuthFunction, context: Context, data_dict: DataDict) -> AuthResult:
-    if data_dict['object_type'] == 'package':
-        try:
-            toolkit.check_access('package_update', context, {'id': data_dict['object']})
-        except toolkit.NotAuthorized:
-            return {'success': False,
-                    'message': 'Only dataset owners can modify dataset groups'}
-
-    return next_auth(context, data_dict)
+    match data_dict['object_type']:
+        case 'package':
+            try:
+                toolkit.check_access('package_update', context, {'id': data_dict['object']})
+                return next_auth(context, data_dict)
+            except toolkit.NotAuthorized:
+                return {'success': False,
+                        'message': 'Only dataset owners can modify dataset groups'}
+        case 'user':
+            return sysadmin_only(context, data_dict)
+        case _:
+            return next_auth(context, data_dict)
 
 @toolkit.chained_auth_function
 def member_delete(next_auth: AuthFunction, context: Context, data_dict: DataDict) -> AuthResult:
-    if data_dict['object_type'] == 'package':
-        try:
-            toolkit.check_access('package_update', context, {'id': data_dict['object']})
-        except toolkit.NotAuthorized:
-            return {'success': False,
-                    'message': 'Only dataset owners can modify dataset groups'}
-
-    return next_auth(context, data_dict)
+    match data_dict['object_type']:
+        case 'package':
+            try:
+                toolkit.check_access('package_update', context, {'id': data_dict['object']})
+                return next_auth(context, data_dict)
+            except toolkit.NotAuthorized:
+                return {'success': False,
+                        'message': 'Only dataset owners can modify dataset groups'}
+        case 'user':
+            return sysadmin_only(context, data_dict)
+        case _:
+            return next_auth(context, data_dict)
 
 
 def sysadmin_only(contaxt, data_dict):

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/auth.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/auth.py
@@ -7,14 +7,13 @@ def member_create(next_auth: AuthFunction, context: Context, data_dict: DataDict
         case 'package':
             try:
                 toolkit.check_access('package_update', context, {'id': data_dict['object']})
-                return next_auth(context, data_dict)
             except toolkit.NotAuthorized:
                 return {'success': False,
                         'message': 'Only dataset owners can modify dataset groups'}
         case 'user':
             return sysadmin_only(context, data_dict)
-        case _:
-            return next_auth(context, data_dict)
+
+    return next_auth(context, data_dict)
 
 @toolkit.chained_auth_function
 def member_delete(next_auth: AuthFunction, context: Context, data_dict: DataDict) -> AuthResult:
@@ -22,14 +21,13 @@ def member_delete(next_auth: AuthFunction, context: Context, data_dict: DataDict
         case 'package':
             try:
                 toolkit.check_access('package_update', context, {'id': data_dict['object']})
-                return next_auth(context, data_dict)
             except toolkit.NotAuthorized:
                 return {'success': False,
                         'message': 'Only dataset owners can modify dataset groups'}
         case 'user':
             return sysadmin_only(context, data_dict)
-        case _:
-            return next_auth(context, data_dict)
+
+    return next_auth(context, data_dict)
 
 
 def sysadmin_only(contaxt, data_dict):


### PR DESCRIPTION
- modify `member_create` and `member_delete` auth functions to defer to `sysadmin_only` if modifying users belonging to a group
- add a test for modifying organization members with both an organization admin and a sysadmin