### PR TITLE
REKDAT-169: Remove unnecessary text from error page

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/error_document_template.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/error_document_template.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block primary %}
+  <article class="module">
+    <div class="module-content">
+      {{ content }}
+    </div>
+  </article>
+{% endblock %}


### PR DESCRIPTION
- Override `error_document_template.html` and remove all but error content