### PR TITLE
REKDAT-164: Run security scans on push to main

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -3,6 +3,9 @@ name: Run security scans
 on:
   workflow_dispatch:
   pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   sast-scanner:


### PR DESCRIPTION
Security scans need to run on push to main, otherwise they are never run on main branch.