### PR TITLE
REKDAT-172: Limit user profile to sysadmins

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
@@ -218,7 +218,8 @@ class RestrictedDataPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'member_create': auth.member_create,
             'member_delete': auth.member_delete,
             'api_token_create': auth.sysadmin_only,
-            'user_list': auth.sysadmin_only
+            'user_list': auth.sysadmin_only,
+            'user_update': auth.sysadmin_only,
         }
 
 

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/user/dashboard.html
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/templates/user/dashboard.html
@@ -1,7 +1,20 @@
 {% ckan_extends %}
 
-{% block dashboard_nav_links %}
-  {{ h.build_nav_icon('activity.dashboard', _('News feed'), icon='list') }}
-  {{ h.build_nav_icon('dashboard.datasets', h.humanize_entity_type('package', dataset_type, 'my label') or _('My Datasets'), icon='sitemap') }}
-  {{ h.build_nav_icon('dashboard.organizations', h.humanize_entity_type('organization', org_type, 'my label') or _('My Organizations'), icon='building') }}
-{% endblock%}
+{% block page_header %}
+  <header class="module-content page-header hug">
+    <div class="content_action">
+      {% if h.check_access('user_update') %}
+      {% link_for _('Profile settings'), named_route='user.edit', id=user.name, class_='btn btn-default', icon='cog' %}
+      {% endif %}
+    </div>
+    {% block content_primary_nav %}
+      <ul class="nav nav-tabs">
+        {% block dashboard_nav_links %}
+          {{ h.build_nav_icon('activity.dashboard', _('News feed'), icon='list') }}
+          {{ h.build_nav_icon('dashboard.datasets', h.humanize_entity_type('package', dataset_type, 'my label') or _('My Datasets'), icon='sitemap') }}
+          {{ h.build_nav_icon('dashboard.organizations', h.humanize_entity_type('organization', org_type, 'my label') or _('My Organizations'), icon='building') }}
+        {% endblock%}
+      </ul>
+    {% endblock %}
+  </header>
+{% endblock %}

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
@@ -1,4 +1,19 @@
 """
+@pytest.mark.usefixtures("with_plugins", "clean_db")
+def test_normal_user_cannot_view_user_profile(app):
+    user = User()
+    client = app.test_client(use_cookies=True)
+    headers = {"Authorization": APIToken(user=user['name'])["token"]}
+    result = client.get(toolkit.url_for("user.read", id=user['name']), headers=headers)
+    assert result.status_code == 403
+
+    with pytest.raises(NotAuthorized):
+        call_action('user_show',
+                    context={"user": user["name"], "ignore_auth": False},
+                    id=user["name"])
+
+
+
 Tests for plugin.py.
 
 Tests are written using the pytest library (https://docs.pytest.org), and you
@@ -586,9 +601,9 @@ def test_paha_authentication_grants_temporary_membership(app):
     response = client.get(toolkit.url_for("organization.edit", id=organization['name']), headers=headers)
     assert response.status_code == 200
 
-    # Use same session to open user edit view
+    # Use same session to open user dashboard view
     # NOTE: new package view would be better, but it depends on building assets with gulp
-    response = client.get(toolkit.url_for("user.edit", id=user["id"]))
+    response = client.get(toolkit.url_for("dashboard.datasets", id=user["id"]))
     assert response.status_code == 200
 
     # Actually create a new dataset as the user

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
@@ -51,7 +51,7 @@ import pytest
 import datetime
 
 from ckan.plugins import plugin_loaded, toolkit
-from ckan.tests.factories import Dataset, Sysadmin, Organization, User, Group
+from ckan.tests.factories import Dataset, Sysadmin, Organization, User, Group, APIToken
 from ckan.tests.helpers import call_action
 from ckan.plugins.toolkit import NotAuthorized
 from .utils import (minimal_dataset, minimal_dataset_with_one_resource_fields,
@@ -713,3 +713,18 @@ def test_only_sysadmin_can_manage_organization_members():
     # Verify another_user is not in organization members
     members = call_action('member_list', id=organization["id"], object_type="user", capacity="member")
     assert all(member_id != another_user["id"] for member_id, _, _ in members)
+
+
+@pytest.mark.usefixtures("with_plugins", "clean_db")
+def test_normal_user_cannot_edit_user_profile(app):
+    user = User()
+    client = app.test_client(use_cookies=True)
+    headers = {"Authorization": APIToken(user=user['name'])["token"]}
+    result = client.get(toolkit.url_for("user.edit", id=user['name']), headers=headers)
+    assert result.status_code == 403
+
+    with pytest.raises(NotAuthorized):
+        call_action('user_patch',
+                    context={"user": user["name"], "ignore_auth": False},
+                    id=user["name"],
+                    fullname="Test full name")


### PR DESCRIPTION
- Limit `user_update` actions to sysadmins
- Show "Profile settings" button only if user is permitted to update users
- Added a test for a normal user trying to open their user profile edit page or modifyign their profile over API