### PR TITLE
REKDAT-196: Reduce AZ count on dev to 2

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -78,7 +78,8 @@ const VpcStackDev = new VpcStack(app, 'VpcStack-dev', {
   env: {
     account: devStackProps.account,
     region: devStackProps.region
-  }
+  },
+  maxAzs: 2
 })
 
 
@@ -307,7 +308,8 @@ const VpcStackProd = new VpcStack(app, 'VpcStack-prod', {
   env: {
     account: prodStackProps.account,
     region: prodStackProps.region
-  }
+  },
+  maxAzs: 3
 })
 
 const KmsKeyStackProd = new KmsKeyStack(app, 'KmsKeyStack-prod', {

--- a/cdk/lib/vpc-stack-props.ts
+++ b/cdk/lib/vpc-stack-props.ts
@@ -1,0 +1,5 @@
+import {StackProps} from "aws-cdk-lib";
+
+export interface VpcStackProps extends StackProps {
+  maxAzs: number
+}

--- a/cdk/lib/vpc-stack.ts
+++ b/cdk/lib/vpc-stack.ts
@@ -1,16 +1,17 @@
-import {aws_ec2, Stack, StackProps} from "aws-cdk-lib";
+import {aws_ec2, Stack} from "aws-cdk-lib";
 import {Construct} from "constructs";
+import {VpcStackProps} from "./vpc-stack-props";
 
 export class VpcStack extends Stack {
-    readonly vpc: aws_ec2.IVpc;
-    constructor(scope: Construct, id: string, props?: StackProps) {
-        super(scope, id, props);
+  readonly vpc: aws_ec2.IVpc;
 
+  constructor(scope: Construct, id: string, props: VpcStackProps) {
+    super(scope, id, props);
 
-        this.vpc = new aws_ec2.Vpc(this, "Vpc", {
-            ipAddresses: aws_ec2.IpAddresses.cidr("10.0.0.0/16")
-        })
+    this.vpc = new aws_ec2.Vpc(this, "Vpc", {
+      ipAddresses: aws_ec2.IpAddresses.cidr("10.0.0.0/16"),
+      maxAzs: props.maxAzs
+    })
 
-
-    }
+  }
 }

--- a/cdk/test/vpc-stack.test.ts
+++ b/cdk/test/vpc-stack.test.ts
@@ -4,7 +4,7 @@ import { VpcStack } from '../lib/vpc-stack';
 
 test('VPC Created with given cidr block', () => {
     const app = new cdk.App();
-    const stack = new VpcStack(app, 'VpcStack-test');
+    const stack = new VpcStack(app, 'VpcStack-test', {maxAzs: 3});
 
     const template = Template.fromStack(stack);
 


### PR DESCRIPTION
Has some cost savings as number of nat gateways also drop to two, requires manually building everything again due to dependencies on subsequent stacks.