### PR TITLE
Install ckan via pypi, no need to install via github anymore

### DIFF
--- a/ckan/ckan-requirements.in
+++ b/ckan/ckan-requirements.in
@@ -1,7 +1,7 @@
 # This file defines the used CKAN version and any overrides
 # Compile with pip-compile to produce the ckan-requirements.txt used in build
 
-ckan[requirements] @ git+https://github.com/ckan/ckan.git@ckan-2.10.5
+ckan[requirements]==2.10.5
 
 # Runtime requirements
 uWSGI==2.0.26

--- a/ckan/ckan-requirements.txt
+++ b/ckan/ckan-requirements.txt
@@ -23,7 +23,7 @@ charset-normalizer==2.0.12
     #   ckan
     #   requests
 # Removed manually for installing editable separately
-#ckan @ git+https://github.com/ckan/ckan.git@66abe426634625b9cad7a67728e481f554436412
+#ckan==2.10.5
     # via -r ckan-requirements.in
 click==8.1.3
     # via


### PR DESCRIPTION
Editable installs required installation via github, ckan is now installed separately so dependencies can be parsed from pypi, might fix dependabot version checks.