### PR TITLE
REKDAT-253: Disable user reset views for anonymous/normal users

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
@@ -224,6 +224,8 @@ class RestrictedDataPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'api_token_create': auth.sysadmin_only,
             'user_list': auth.sysadmin_only,
             'user_update': auth.sysadmin_only,
+            'request_reset': auth.sysadmin_only,
+            'user_reset': auth.sysadmin_only,
         }
 
 

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
@@ -796,3 +796,26 @@ def test_normal_user_cannot_edit_user_profile(app):
                     context={"user": user["name"], "ignore_auth": False},
                     id=user["name"],
                     fullname="Test full name")
+        
+@pytest.mark.usefixtures("with_plugins", "clean_db")
+def test_normal_user_cannot_request_reset(app):
+    client = app.test_client(use_cookies=True)
+    user = User()
+    request_reset = toolkit.url_for("user.request_reset")
+
+    # Anonymous user get
+    result = client.get(request_reset)
+    assert result.status_code == 403
+    
+    # Anonymous user post
+    result = client.post(request_reset, data={'id': user['id']})
+    assert result.status_code == 403
+
+    # Logged in normal user get
+    headers = {"Authorization": APIToken(user=user['name'])["token"]}
+    result = client.get(request_reset, headers=headers)
+    assert result.status_code == 403
+
+    # Logged in normal user post
+    result = client.post(request_reset, headers=headers, data={'id': user['id']})
+    assert result.status_code == 403


### PR DESCRIPTION
- disable request_reset and user_reset to disable requesting and performing resets for users
- added a test for requesting resets. performing is not possible because requests cannot be made