### PR TITLE
REKDAT-309: Improve error reporting in paha authorize endpoint

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/action.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/action.py
@@ -61,6 +61,13 @@ def _decode_paha_jwt_token(encoded_token: str):
         # Fallback to regular auth if anything at all goes wrong with the token
         return
 
+    required_fields = ['iss', 'id', 'email', 'firstName', 'lastName', 'activeOrganizationId',
+                       'activeOrganizationNameFi', 'activeOrganizationNameSv',
+                       'activeOrganizationNameEn', 'expiresIn']
+    if any(field not in token for field in required_fields):
+        error = f'Token did not contain required fields: {", ".join(required_fields)}'
+        raise toolkit.ValidationError(error)
+
     if token.get('iss') != 'PAHA':
         return
 

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/utils.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/utils.py
@@ -38,6 +38,14 @@ def minimal_group():
 def create_paha_token(data, private_key_file='jwtRS256.valid.key'):
     payload = {
         "iss": "PAHA",
+        "id": "user-id",
+        "email": "foo.bar@example.com",
+        "firstName": "Foo",
+        "lastName": "Bar",
+        "activeOrganizationId": "organization-id",
+        "activeOrganizationNameFi": "organization name fi",
+        "activeOrganizationNameSv": "organization name sv",
+        "activeOrganizationNameEn": "organization name en",
         "expiresIn": int((datetime.datetime.now() + datetime.timedelta(days=1)).timestamp() * 1000),
     }
     payload.update(data)

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/views.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/views.py
@@ -1,6 +1,6 @@
 from ckan.plugins import toolkit
 from ckan.views.dataset import GroupView as CkanDatasetGroupView
-from flask import Blueprint
+from flask import Blueprint, make_response
 import logging
 
 log = logging.getLogger(__name__)
@@ -38,8 +38,13 @@ restricted_data_dataset.add_url_rule(u'/groups/<id>', view_func=GroupView.as_vie
 
 def authorize():
     paha_token = toolkit.request.data
-    token = toolkit.get_action('authorize_paha_session')({'ignore_auth': True}, {'token': paha_token})
-    return {'token': token}
+    try:
+        token = toolkit.get_action('authorize_paha_session')({'ignore_auth': True}, {'token': paha_token})
+        return {'token': token}
+    except toolkit.ValidationError as e:
+        body = {'error': e.error_dict['message']}
+        headers = {'Content-Type': 'application/json'}
+        return make_response(body, 400, headers)
 
 paha.add_url_rule('/authorize', view_func=authorize, methods=['POST'])
 


### PR DESCRIPTION
- Check required fields when decoding paha jwt
- Return HTTP 400 with an error json if fields are missing
- Add test to verify this