### PR TITLE
REKDAT-309: Add fallback language for PAHA auth created organizations

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/action.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/action.py
@@ -147,7 +147,10 @@ def _create_or_get_paha_organization(token: str):
 
         existing_organization_names = set(toolkit.get_action('organization_list')({'ignore_auth': True}, {}))
         if len(existing_organization_names) >= 1000:
-            log.error("Organization count over 1000, fix PAHA organization code")
+            log.error("""Organization count over max returned by organization_list.
+                         This may cause errors in generating unique organization names in PAHA auth,
+                         and should be fixed by increasing ckan.group_and_organization_list_max
+                         or by implementing paged fetch for organization names.""")
 
         organization_name = munge_title_to_name(organization_title)
         for i in range(2, 100):

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/views.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/views.py
@@ -42,7 +42,7 @@ def authorize():
         token = toolkit.get_action('authorize_paha_session')({'ignore_auth': True}, {'token': paha_token})
         return {'token': token}
     except toolkit.ValidationError as e:
-        body = {'error': e.error_dict['message']}
+        body = e.error_dict
         headers = {'Content-Type': 'application/json'}
         return make_response(body, 400, headers)
 


### PR DESCRIPTION
- Use finnish organization title for sv/en titles if they are empty
- Support multiple organizations with the same title in name generation
- Support different validation error types in paha authorize endpoint
- Amend test for organization title fallback language