### PR TITLE
REKDAT-361: Added IP restriction support for paha endpoints

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -20,6 +20,7 @@ import {CkanStack} from "../lib/ckan-stack";
 import {ShieldParameterStack} from "../lib/shield-parameter-stack";
 import {ShieldStack} from "../lib/shield-stack";
 import {MonitoringStack} from '../lib/monitoring-stack';
+import { RestricteddataParameterStack } from '../lib/restricteddata-parameter-stack';
 
 const app = new cdk.App();
 
@@ -175,6 +176,14 @@ const FileSystemStackDev = new FileSystemStack(app, 'FilesystemStack-dev', {
   terminationProtection: true
 })
 
+const RestricteddataParameterStackDev = new RestricteddataParameterStack(app, 'RestricteddataParameterStack-dev', {
+  env: {
+    account: devStackProps.account,
+    region: devStackProps.region,
+  },
+  environment: devStackProps.environment,
+})
+
 
 const NginxStackDev = new NginxStack(app, 'NginxStack-dev', {
   env: {
@@ -201,8 +210,8 @@ const NginxStackDev = new NginxStack(app, 'NginxStack-dev', {
     taskMem: 512,
     taskMinCapacity: 1,
     taskMaxCapacity: 1
-  }
-
+  },
+  authSourceAddress: RestricteddataParameterStackDev.authSourceAddress
 })
 
 const SolrStackDev = new SolrStack(app, 'SolrStack-dev', {
@@ -398,6 +407,14 @@ const FileSystemStackProd = new FileSystemStack(app, 'FilesystemStack-prod', {
 })
 
 
+const RestricteddataParameterStackProd = new RestricteddataParameterStack(app, 'RestricteddataParameterStack-prod', {
+  env: {
+    account: prodStackProps.account,
+    region: prodStackProps.region,
+  },
+  environment: prodStackProps.environment,
+})
+
 const NginxStackProd = new NginxStack(app, 'NginxStack-prod', {
   env: {
     account: prodStackProps.account,
@@ -423,8 +440,8 @@ const NginxStackProd = new NginxStack(app, 'NginxStack-prod', {
     taskMem: 512,
     taskMinCapacity: 1,
     taskMaxCapacity: 1
-  }
-
+  },
+  authSourceAddress: RestricteddataParameterStackProd.authSourceAddress
 })
 
 const SolrStackProd = new SolrStack(app, 'SolrStack-prod', {

--- a/cdk/lib/nginx-stack-props.ts
+++ b/cdk/lib/nginx-stack-props.ts
@@ -1,5 +1,5 @@
 import {EcsStackProps} from "./ecs-stack-props";
-import {aws_certificatemanager, aws_elasticloadbalancingv2, aws_route53} from "aws-cdk-lib";
+import {aws_certificatemanager, aws_elasticloadbalancingv2, aws_route53, aws_ssm} from "aws-cdk-lib";
 
 export interface NginxStackProps extends EcsStackProps {
   allowRobots: string,
@@ -12,5 +12,5 @@ export interface NginxStackProps extends EcsStackProps {
   secondaryDomainName: string,
   fqdn: string,
   secondaryFqdn: string,
-
+  authSourceAddress: aws_ssm.IStringParameter
 }

--- a/cdk/lib/nginx-stack.ts
+++ b/cdk/lib/nginx-stack.ts
@@ -1,7 +1,6 @@
 import {
   aws_ecr,
   aws_ecs,
-  aws_ssm,
   aws_ecs_patterns,
   aws_elasticloadbalancingv2,
   aws_logs, aws_route53, aws_route53_targets,
@@ -48,10 +47,6 @@ export class NginxStack extends Stack {
     const nginxCspWorkerSrc: string[] = [];
 
 
-    const pAuthSourceAddress = aws_ssm.StringParameter.fromStringParameterAttributes(this, 'pAuthSourceAddress', {
-      parameterName: `/${props.environment}/restricteddata/auth_source_address`,
-    });
-
     const nginxContainer = nginxTaskDefinition.addContainer('nginx', {
       image: aws_ecs.ContainerImage.fromEcrRepository(nginxRepo, props.envProps.NGINX_IMAGE_TAG),
       environment: {
@@ -77,7 +72,7 @@ export class NginxStack extends Stack {
         CKAN_PORT: '5000',
         NGINX_ROBOTS_ALLOW: props.allowRobots,
         NGINX_PROXY_ADDRESS: props.loadBalancer.loadBalancerDnsName,
-        AUTH_SOURCE_ADDRESS: pAuthSourceAddress.stringValue,
+        AUTH_SOURCE_ADDRESS: props.authSourceAddress.stringValue,
       },
       logging: aws_ecs.LogDrivers.awsLogs({
         logGroup: nginxLogGroup,

--- a/cdk/lib/restricteddata-parameter-stack.ts
+++ b/cdk/lib/restricteddata-parameter-stack.ts
@@ -1,0 +1,18 @@
+import {aws_ssm, Stack} from "aws-cdk-lib";
+import {Construct} from "constructs";
+
+import {EnvStackProps} from "./env-stack-props";
+
+export class RestricteddataParameterStack extends Stack {
+  readonly authSourceAddress: aws_ssm.IStringParameter;
+
+  constructor(scope: Construct, id: string, props: EnvStackProps ) {
+    super(scope, id, props);
+
+    this.authSourceAddress = new aws_ssm.StringParameter(this, 'authSourceAddress', {
+      stringValue: '127.0.0.1',
+      description: 'Authentication source IP address',
+      parameterName: `/${props.environment}/restricteddata/auth_source_address`
+    })
+  }
+}

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/action.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/action.py
@@ -182,7 +182,7 @@ def authorize_paha_session(context: Context, data_dict: DataDict):
     paha_jwt_token = _decode_paha_jwt_token(encoded_token)
     if not paha_jwt_token:
         log.error("No valid PAHA JWT provided")
-        return toolkit.abort(400)
+        raise toolkit.ValidationError("No valid PAHA JWT provided")
 
     user = _create_or_authenticate_paha_user(paha_jwt_token)
     organization = _create_or_get_paha_organization(paha_jwt_token)

--- a/docker/.env.template
+++ b/docker/.env.template
@@ -78,3 +78,5 @@ CKAN_PORT=5000
 # nginx
 NGINX_HOST=nginx
 NGINX_PORT=80
+NGINX_PROXY_ADDRESS=172.20.0.1/32  # docker host ip
+AUTH_SOURCE_ADDRESS=172.20.0.2/32  # another IP from the same pool for testing

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -155,6 +155,8 @@ services:
       - NAMESERVER=${NAMESERVER}
       - CKAN_HOST=${CKAN_HOST}
       - CKAN_PORT=${CKAN_PORT}
+      - NGINX_PROXY_ADDRESS=${NGINX_PROXY_ADDRESS}
+      - AUTH_SOURCE_ADDRESS=${AUTH_SOURCE_ADDRESS}
 
   mailhog:
     image: mailhog/mailhog:latest

--- a/docker/nginx/templates/server.conf.template
+++ b/docker/nginx/templates/server.conf.template
@@ -50,6 +50,15 @@ location ~ ^/(.*)$ {
     add_header Cache-Control private;
   }
 
+  location ~ ^/paha(.*)$ {
+    proxy_pass http://$ckan_target/paha$1$is_args$args;
+    set_real_ip_from  ${NGINX_PROXY_ADDRESS};
+    real_ip_header    X-Forwarded-For;
+    real_ip_recursive on;
+    allow ${AUTH_SOURCE_ADDRESS};
+    deny all;
+  }
+
   location ~ /(fi|en_GB|sv)/organization/(.*)/embed {
     proxy_pass http://$ckan_target/$1/organization/$2/embed$is_args$args;
 

--- a/docker/nginx/templates/server.conf.template
+++ b/docker/nginx/templates/server.conf.template
@@ -50,8 +50,8 @@ location ~ ^/(.*)$ {
     add_header Cache-Control private;
   }
 
-  location ~ ^/paha(.*)$ {
-    proxy_pass http://$ckan_target/paha$1$is_args$args;
+  location ~ ^/paha/(.*)$ {
+    proxy_pass http://$ckan_target/paha/$1$is_args$args;
     set_real_ip_from  ${NGINX_PROXY_ADDRESS};
     real_ip_header    X-Forwarded-For;
     real_ip_recursive on;


### PR DESCRIPTION
- Add realip/allow/deny directives to nginx conf for /paha paths
- Add docker compatible default values for trusted proxy and authentication source address
- Implement CDK support for setting values for trusted proxy and authentication source address
- Fix /paha/authorize response on invalid or missing token