### PR TITLE
Update aws-cdk-lib to 2.145.0 in order to fix notice 29949

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.370.0",
-        "aws-cdk-lib": "2.140.0",
+        "aws-cdk-lib": "2.145.0",
         "constructs": "^10.0.0",
         "dotenv": "^16.3.1",
         "form-data": "^4.0.0",
@@ -2358,9 +2358,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.140.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.140.0.tgz",
-      "integrity": "sha512-wepu+u63LTxnIfW/IPr+V5Mx1T9jq8HRxhPynYPQKFYaKfOV+6HtJGxkuAEg2CWXk0rx2Btal/BCLjYQovI92Q==",
+      "version": "2.145.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.145.0.tgz",
+      "integrity": "sha512-0RCKdojCtF74rI2gGi9KUFVUKykTIMEs3ANjruIjxEz6d2cAsy9c2k+nCCSMdqhKZ9aPJgmBFewiw03Z8NtPig==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -2374,6 +2374,7 @@
         "yaml",
         "mime-types"
       ],
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.202",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.370.0",
-    "aws-cdk-lib": "2.140.0",
+    "aws-cdk-lib": "2.145.0",
     "constructs": "^10.0.0",
     "dotenv": "^16.3.1",
     "form-data": "^4.0.0",


### PR DESCRIPTION
- aws-cdk-lib 2.145.0 fixes https://github.com/aws/aws-cdk/releases/tag/v2.145.0 custom resources warning per notice 29949 