### PR TITLE
REKDAT-361: Modify auth source address system to allow multiple ip addresses

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -211,7 +211,7 @@ const NginxStackDev = new NginxStack(app, 'NginxStack-dev', {
     taskMinCapacity: 1,
     taskMaxCapacity: 1
   },
-  authSourceAddress: RestricteddataParameterStackDev.authSourceAddress
+  authSourceAddresses: RestricteddataParameterStackDev.authSourceAddresses
 })
 
 const SolrStackDev = new SolrStack(app, 'SolrStack-dev', {
@@ -441,7 +441,7 @@ const NginxStackProd = new NginxStack(app, 'NginxStack-prod', {
     taskMinCapacity: 1,
     taskMaxCapacity: 1
   },
-  authSourceAddress: RestricteddataParameterStackProd.authSourceAddress
+  authSourceAddresses: RestricteddataParameterStackProd.authSourceAddresses
 })
 
 const SolrStackProd = new SolrStack(app, 'SolrStack-prod', {

--- a/cdk/lib/nginx-stack-props.ts
+++ b/cdk/lib/nginx-stack-props.ts
@@ -12,5 +12,5 @@ export interface NginxStackProps extends EcsStackProps {
   secondaryDomainName: string,
   fqdn: string,
   secondaryFqdn: string,
-  authSourceAddress: aws_ssm.IStringParameter
+  authSourceAddresses: aws_ssm.IStringListParameter
 }

--- a/cdk/lib/nginx-stack.ts
+++ b/cdk/lib/nginx-stack.ts
@@ -1,4 +1,5 @@
 import {
+  Fn,
   aws_ecr,
   aws_ecs,
   aws_ecs_patterns,
@@ -72,7 +73,7 @@ export class NginxStack extends Stack {
         CKAN_PORT: '5000',
         NGINX_ROBOTS_ALLOW: props.allowRobots,
         NGINX_PROXY_ADDRESS: props.loadBalancer.loadBalancerDnsName,
-        AUTH_SOURCE_ADDRESS: props.authSourceAddress.stringValue,
+        AUTH_SOURCE_ADDRESSES: Fn.join(',', props.authSourceAddresses.stringListValue)
       },
       logging: aws_ecs.LogDrivers.awsLogs({
         logGroup: nginxLogGroup,

--- a/cdk/lib/restricteddata-parameter-stack.ts
+++ b/cdk/lib/restricteddata-parameter-stack.ts
@@ -4,15 +4,15 @@ import {Construct} from "constructs";
 import {EnvStackProps} from "./env-stack-props";
 
 export class RestricteddataParameterStack extends Stack {
-  readonly authSourceAddress: aws_ssm.IStringParameter;
+  readonly authSourceAddresses: aws_ssm.IStringListParameter;
 
   constructor(scope: Construct, id: string, props: EnvStackProps ) {
     super(scope, id, props);
 
-    this.authSourceAddress = new aws_ssm.StringParameter(this, 'authSourceAddress', {
-      stringValue: '127.0.0.1',
-      description: 'Authentication source IP address',
-      parameterName: `/${props.environment}/restricteddata/auth_source_address`
+    this.authSourceAddresses = new aws_ssm.StringListParameter(this, 'authSourceAddresses', {
+      stringListValue: ['127.0.0.1'],
+      description: 'Authentication source IP address list',
+      parameterName: `/${props.environment}/restricteddata/auth_source_addresses`
     })
   }
 }

--- a/docker/.env.template
+++ b/docker/.env.template
@@ -78,5 +78,5 @@ CKAN_PORT=5000
 # nginx
 NGINX_HOST=nginx
 NGINX_PORT=80
-NGINX_PROXY_ADDRESS=172.20.0.1/32  # docker host ip
-AUTH_SOURCE_ADDRESS=172.20.0.2/32  # another IP from the same pool for testing
+NGINX_PROXY_ADDRESS=172.20.0.1/32                     # docker host ip
+AUTH_SOURCE_ADDRESSES="172.20.0.2/32, 172.20.0.3/32"  # other IPs from the same pool for testing

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -156,7 +156,7 @@ services:
       - CKAN_HOST=${CKAN_HOST}
       - CKAN_PORT=${CKAN_PORT}
       - NGINX_PROXY_ADDRESS=${NGINX_PROXY_ADDRESS}
-      - AUTH_SOURCE_ADDRESS=${AUTH_SOURCE_ADDRESS}
+      - AUTH_SOURCE_ADDRESSES=${AUTH_SOURCE_ADDRESSES}
 
   mailhog:
     image: mailhog/mailhog:latest

--- a/docker/nginx/docker-entrypoint.d/100-install-jinja2-templates.sh
+++ b/docker/nginx/docker-entrypoint.d/100-install-jinja2-templates.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
 set -e
 
-jinja2 /etc/nginx/jinja2-templates/robots.txt.j2 -o /var/www/robots.txt
+jinja2 /etc/nginx/jinja2-templates/robots.txt.j2 \
+  -o /var/www/robots.txt
+
+jinja2 /etc/nginx/jinja2-templates/server.conf.j2 \
+  -D "auth_source_addresses=${AUTH_SOURCE_ADDRESSES}" \
+  -o /etc/nginx/templates/server.conf.template

--- a/docker/nginx/jinja2-templates/server.conf.j2
+++ b/docker/nginx/jinja2-templates/server.conf.j2
@@ -55,7 +55,10 @@ location ~ ^/(.*)$ {
     set_real_ip_from  ${NGINX_PROXY_ADDRESS};
     real_ip_header    X-Forwarded-For;
     real_ip_recursive on;
-    allow ${AUTH_SOURCE_ADDRESS};
+    # Process auth source address list into allow directives
+    {% for ip in auth_source_addresses.split(',') %}
+    allow {{ ip|trim }};
+    {% endfor %}
     deny all;
   }
 
@@ -73,4 +76,5 @@ location ~ ^/(.*)$ {
     proxy_intercept_errors off;
   }
 }
+
 


### PR DESCRIPTION
- Change parameter name to auth_source_addresses
- Change parameter type to string list
- Make server.conf a jinja2 template to unpack allow statements from an environment variable
- Pass AUTH_SOURCE_ADDRESSES environment variable to server.conf.j2 rendering
- .env.template and CDK changes to populate AUTH_SOURCE_ADDRESS environment variable