### PR TITLE
REKDAT-361: Fix nginx template generation priority issue

### DIFF
--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -11,7 +11,7 @@ COPY templates /etc/nginx/templates
 COPY jinja2-templates /etc/nginx/jinja2-templates
 
 # install entrypoint scripts
-COPY docker-entrypoint.d/100-install-jinja2-templates.sh /docker-entrypoint.d/
+COPY docker-entrypoint.d/17-install-jinja2-templates.sh /docker-entrypoint.d/
 RUN chmod +x /docker-entrypoint.d/*.sh
 
 RUN mkdir /var/www

--- a/docker/nginx/docker-entrypoint.d/100-install-jinja2-templates.sh
+++ b/docker/nginx/docker-entrypoint.d/100-install-jinja2-templates.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-set -e
-
-jinja2 /etc/nginx/jinja2-templates/robots.txt.j2 \
-  -o /var/www/robots.txt
-
-jinja2 /etc/nginx/jinja2-templates/server.conf.j2 \
-  -D "auth_source_addresses=${AUTH_SOURCE_ADDRESSES}" \
-  -o /etc/nginx/templates/server.conf.template

--- a/docker/nginx/docker-entrypoint.d/17-install-jinja2-templates.sh
+++ b/docker/nginx/docker-entrypoint.d/17-install-jinja2-templates.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+# Needs to run before envsubst at priority 20
+
+# Data required because of a quirk in entrypoint.d handling
+# otherwise jinja2 will try to use the next entrypoint script
+# as a JSON data file
+echo "{}" | jinja2 /etc/nginx/jinja2-templates/robots.txt.j2 \
+  > /var/www/robots.txt ;
+
+echo "{}" |jinja2 /etc/nginx/jinja2-templates/server.conf.j2 \
+  -D "auth_source_addresses=${AUTH_SOURCE_ADDRESSES}" \
+  > /etc/nginx/templates/server.conf.template ;


### PR DESCRIPTION
- Jinja2 template rendering happened after nginx template instantiation in priority
- Set priority to 17 so it happens before 20
- Handle some quirks in how entrypoint.d works in the script