### PR TITLE
REKDAT-229: Get default translations for distribution name from url field

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
@@ -93,7 +93,8 @@ class RestrictedDataPlugin(plugins.SingletonPlugin, DefaultTranslation):
             validators.convert_to_json_compatible_str_if_str,
             'required_languages': validators.required_languages,
             'highvalue_category': validators.highvalue_category,
-            'highvalue': validators.highvalue
+            'highvalue': validators.highvalue,
+            'populate_required_languages_from_field_if_missing': validators.populate_required_languages_from_field_if_missing,
         }
 
     # IPackageController

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/schemas/dataset.json
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/schemas/dataset.json
@@ -302,13 +302,18 @@
         "sv",
         "en"
       ],
+      "required_languages": [
+        "fi",
+        "sv"
+      ],
       "form_placeholder": "e.g. Most popular Finnish first names 2019",
       "form_attrs": {
         "class": "form-control"
       },
       "description": "Give a short and descriptive name for the distribution. If the data covers a specific time frame, mention that in the name.",
       "group_title": "Data resource title",
-      "group_description": "* Required field"
+      "group_description": "* Required field",
+      "validators": "fluent_text populate_required_languages_from_field_if_missing(url)"
     },
     {
       "field_name": "url",

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
@@ -104,6 +104,7 @@ def test_minimal_dataset():
     assert len(dataset['resources']) == 1
     resource = dataset['resources'][0]
     assert resource['url'] == dataset_fields['resources'][0]['url']
+    assert resource['name_translated']['fi'] == resource['url']
 
 
 @pytest.mark.usefixtures("with_plugins", "clean_db")

--- a/robot/restricteddata.robot
+++ b/robot/restricteddata.robot
@@ -312,17 +312,13 @@ Fill Dataset Form With Full Test Data
     Input Text  id:field-maintainer_website  ${maintenance website}
 
 Fill Resource Form With Minimal Test Data
-    [Arguments]  ${name fi}=Testiresurssi
-    ...          ${name sv}=Test resurs
-    ...          ${description fi}=Testiresurssin kuvaus
+    [Arguments]  ${description fi}=Testiresurssin kuvaus
     ...          ${description sv}=Test resurs beskrivning
     ...          ${url}=https://example.com
     ...          ${format}=HTML
     ...          ${size}=12345
     ...          ${rights fi}=Testiresurssin käyttöoikeuksien kuvaus
     ...          ${rights sv}=Test resurs användningsrättigheter
-    Input Text  id:field-name_translated-fi  ${name fi}
-    Input Text  id:field-name_translated-sv  ${name sv}
     TRY
         Click Button  id:resource-link-button
     EXCEPT
@@ -355,10 +351,11 @@ Fill Resource Form With Full Test Data
     ...          ${temporal coverage from}=01/02/2023
     ...          ${temporal coverage till}=03/04/2033
     ...          ${geographical accuracy}=42
-    Fill Resource Form With Minimal Test Data  name fi=${name fi}  name sv=${name sv}
-    ...                                        description fi=${description fi}  description sv=${description sv}
+    Fill Resource Form With Minimal Test Data  description fi=${description fi}  description sv=${description sv}
     ...                                        url=${url}  format=${format}  size=${size}
     ...                                        rights fi=${rights fi}  rights sv=${rights sv}
+    Input Text  id:field-name_translated-fi  ${name fi}
+    Input Text  id:field-name_translated-sv  ${name sv}
     Input Text  id:field-name_translated-en  Test resource
     Input Text Into CKEditor  field-description_translated-fi  ${description fi}
     Input Text Into CKEditor  field-description_translated-sv  ${description sv}

--- a/robot/tests/dataset.robot
+++ b/robot/tests/dataset.robot
@@ -17,7 +17,7 @@ Create Minimal Dataset And Resource
     Submit Primary Form
     
     URL Path Should Be  /dataset/testiaineisto/resource/new
-    Fill Resource Form With Minimal Test Data
+    Fill Resource Form With Minimal Test Data  url=http://example.com/test-resource
     Submit Primary Form
     
     URL Path Should Be  /dataset/testiaineisto
@@ -25,7 +25,7 @@ Create Minimal Dataset And Resource
     Page Should Contain  Teemu Testaaja
     Page Should Contain  teemu.testaaja@example.com
         
-    Click Link  link:Testiresurssi
+    Click Link  http://example.com/test-resource
     Page Should Contain  12345
     Page Should Contain  Testiresurssin käyttöoikeuksien kuvaus
     

--- a/robot/tests/distribution.robot
+++ b/robot/tests/distribution.robot
@@ -113,8 +113,8 @@ Remove Distribution
     Fill Resource Form With Minimal Test Data
     Submit Primary Form
 
-    URL Path Should Be  /dataset/testiaineisto
-    Click Link  Testiresurssi
+    URL Path Should Be  /dataset/testiaineisto  url=http://example.com/test-resource
+    Click Link  http://example.com/test-resource
     Click Link  Muokkaa 
 
     Scroll To Form Actions

--- a/robot/tests/distribution.robot
+++ b/robot/tests/distribution.robot
@@ -110,10 +110,10 @@ Remove Distribution
     Submit Primary Form
     
     URL Path Should Be  /dataset/testiaineisto/resource/new
-    Fill Resource Form With Minimal Test Data
+    Fill Resource Form With Minimal Test Data  url=http://example.com/test-resource
     Submit Primary Form
 
-    URL Path Should Be  /dataset/testiaineisto  url=http://example.com/test-resource
+    URL Path Should Be  /dataset/testiaineisto
     Click Link  http://example.com/test-resource
     Click Link  Muokkaa 
 


### PR DESCRIPTION
- Added validator `populate_required_languages_from_field_if_missing`
- Set validator to distribution `name_translated` field
- Set `required_languages` to distribution `name_translated` field
- Update tests