### PR TITLE
REKDAT-395: Make swedish optional

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/action.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/logic/action.py
@@ -133,11 +133,9 @@ def _create_or_get_paha_organization(token: str):
 
     except toolkit.ObjectNotFound:
         name_languages = ['fi', 'sv', 'en']
-        fallback_language = 'fi'
 
         title_field = 'activeOrganizationName{}'.format
-        organization_titles = {lang: (token[title_field(lang.capitalize())]
-                                      or token[title_field(fallback_language.capitalize())])
+        organization_titles = {lang: token.get(title_field(lang.capitalize()), '')
                                for lang in name_languages}
         organization_title = next((organization_titles[lang]
                                   for lang in name_languages

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/schemas/dataset.json
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/schemas/dataset.json
@@ -14,8 +14,7 @@
       ],
       "form_placeholder": "e.g. Finnish names",
       "required_languages": [
-        "fi",
-        "sv"
+        "fi"
       ],
       "description": "Give a short and descriptive name for the dataset.<br><br>The URL is created automatically based on the dataset title. If necessary, you can edit the URL.",
       "group_title": "Dataset title",
@@ -43,8 +42,7 @@
       "display_snippet": null,
       "validators": "fluent_text required_languages",
       "required_languages": [
-        "fi",
-        "sv"
+        "fi"
       ],
       "description": "Describe the dataset’s contents, collection process, quality of the data and possible limits, flaws and applications in an easily understandable way.",
       "group_title": "Dataset description"
@@ -62,8 +60,7 @@
       "preset": "fluent_vocabulary_with_autocomplete",
       "validators": "required_languages fluent_tags create_fluent_tags(keywords)",
       "required_languages": [
-        "fi",
-        "sv"
+        "fi"
       ],
       "form_attrs": {
         "data-module": "autocomplete",
@@ -303,8 +300,7 @@
         "en"
       ],
       "required_languages": [
-        "fi",
-        "sv"
+        "fi"
       ],
       "form_placeholder": "e.g. Most popular Finnish first names 2019",
       "form_attrs": {
@@ -374,8 +370,7 @@
         "en"
       ],
       "required_languages": [
-        "fi",
-        "sv"
+        "fi"
       ],
       "form_attrs": {
         "class": "form-control"

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/schemas/group.json
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/schemas/group.json
@@ -13,8 +13,7 @@
         "sv"
       ],
       "required_languages": [
-        "fi",
-        "sv"
+        "fi"
       ],
       "form_placeholder": "My Group"
     },

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/schemas/organization.json
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/schemas/organization.json
@@ -14,8 +14,7 @@
         "en"
       ],
       "required_languages": [
-        "fi",
-        "sv"
+        "fi"
       ],
       "group_title": "Organization name",
       "group_description": "* Required field",

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/factories.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/factories.py
@@ -9,5 +9,4 @@ fake = Faker()
 class RestrictedDataOrganization(Organization):
     title_translated = factory.Dict({
         'fi': factory.LazyFunction(lambda: fake.sentence(nb_words=5)),
-        'sv': factory.LazyFunction(lambda: fake.sentence(nb_words=5))
     })

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_dcat.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_dcat.py
@@ -51,18 +51,15 @@ def test_dcat_dataset_with_minimal_dataset(app):
     Dataset(**dataset_fields)
 
     result = fetch_catalog_graph(app).query('''
-        SELECT ?id ?titleFi ?titleSv ?descriptionFi ?descriptionSv
-               ?keywordFi ?keywordSv ?publisher
+        SELECT ?id ?titleFi ?descriptionFi
+               ?keywordFi ?publisher
                ?accessRights ?maintainer ?maintainerEmail
         WHERE {
             ?a a dcat:Dataset
             . ?a dcterms:identifier ?id
             . ?a dcterms:title ?titleFi FILTER ( lang(?titleFi) = "fi")
-            . ?a dcterms:title ?titleSv FILTER ( lang(?titleSv) = "sv")
             . ?a dcterms:description ?descriptionFi FILTER ( lang(?descriptionFi) = "fi")
-            . ?a dcterms:description ?descriptionSv FILTER ( lang(?descriptionSv) = "sv")
             . ?a dcat:keyword ?keywordFi FILTER ( lang(?keywordFi) = "fi")
-            . ?a dcat:keyword ?keywordSv FILTER ( lang(?keywordSv) = "sv")
             . ?a dcterms:publisher ?publisher
             . ?a dcterms:accessRights ?accessRights
             . ?a dcat:contactPoint ?contact
@@ -71,16 +68,13 @@ def test_dcat_dataset_with_minimal_dataset(app):
         }
         ''')
 
-    [(id, title_fi, title_sv, notes_fi, notes_sv, keyword_fi, keyword_sv,
+    [(id, title_fi, notes_fi, keyword_fi,
       publisher, access_rights, maintainer, maintainer_email)] = list(result)
 
     assert id is not None
     assert title_fi == Literal(dataset_fields['title_translated']['fi'], lang='fi')
-    assert title_sv == Literal(dataset_fields['title_translated']['sv'], lang='sv')
     assert notes_fi == Literal(dataset_fields['notes_translated']['fi'], lang='fi')
-    assert notes_sv == Literal(dataset_fields['notes_translated']['sv'], lang='sv')
     assert keyword_fi == Literal(dataset_fields['keywords']['fi'][0], lang='fi')
-    assert keyword_sv == Literal(dataset_fields['keywords']['sv'][0], lang='sv')
     assert publisher is not None
     assert access_rights == Literal(dataset_fields['access_rights'])
     assert maintainer == Literal(dataset_fields['maintainer'])
@@ -199,7 +193,7 @@ def test_dcat_resource_with_minimal_resource(app):
     Dataset(**dataset_fields)
 
     result = fetch_catalog_graph(app).query('''
-        SELECT ?url ?format ?size ?maturity ?rightsFi ?rightsSv
+        SELECT ?url ?format ?size ?maturity ?rightsFi 
         WHERE {
             ?a a dcat:Distribution
             . ?a dcat:accessURL ?url
@@ -207,18 +201,16 @@ def test_dcat_resource_with_minimal_resource(app):
             . ?a dcat:byteSize ?size
             . ?a adms:status ?maturity
             . ?a dcterms:rights ?rightsFi FILTER ( lang(?rightsFi) = "fi")
-            . ?a dcterms:rights ?rightsSv FILTER ( lang(?rightsSv) = "sv")
         }
         ''')
 
-    [(url, format, size, maturity, rights_fi, rights_sv)] = list(result)
+    [(url, format, size, maturity, rights_fi)] = list(result)
 
     assert url == URIRef(resource_fields['url'])
     assert format == Literal(resource_fields['format'])
     assert size == Literal(resource_fields['size'], datatype=XSD.nonNegativeInteger)
     assert maturity == Literal(resource_fields['maturity'])
     assert rights_fi == Literal(resource_fields['rights_translated']['fi'], lang='fi')
-    assert rights_sv == Literal(resource_fields['rights_translated']['sv'], lang='sv')
 
 
 @pytest.mark.usefixtures("with_plugins", "clean_db", "clean_index")

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
@@ -590,8 +590,8 @@ def test_paha_authentication_creates_organization(app):
     assert organization['id'] == organization_id
     assert organization['title_translated'] == {
         'fi': organization_name_fi,
-        'sv': organization_name_fi,
-        'en': organization_name_fi
+        'sv': '',
+        'en': ''
     }
 
 

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/utils.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/utils.py
@@ -7,12 +7,12 @@ def minimal_dataset(user):
     return dict(
         user=user,
         private=False,
-        title_translated={'fi': 'Title (fi)', 'sv': 'Title (sv)'},
-        notes_translated={'fi': 'Notes (fi)', 'sv': 'Notes (sv)'},
+        title_translated={'fi': 'Title (fi)'},
+        notes_translated={'fi': 'Notes (fi)'},
         access_rights='non-public',
         maintainer='maintainer',
         maintainer_email=['maintainer@example.com'],
-        keywords={'fi': ['test-fi'], 'sv': ['test-sv']},
+        keywords={'fi': ['test-fi']},
     )
 
 
@@ -22,7 +22,7 @@ def minimal_dataset_with_one_resource_fields(user):
             url='http://example.com',
             format='TXT',
             size=1234,
-            rights_translated={'fi': 'Rights (fi)', 'sv': 'Rights (sv)'},
+            rights_translated={'fi': 'Rights (fi)'},
             private=False,
             maturity='current',
         )]
@@ -31,7 +31,7 @@ def minimal_dataset_with_one_resource_fields(user):
 
 def minimal_group():
     return dict(
-        title_translated={lang: f'title {lang}' for lang in ['fi', 'sv']}
+        title_translated={lang: f'title {lang}' for lang in ['fi']}
     )
 
 


### PR DESCRIPTION
- Remove swedish translation requirement from data models
- Remove fallback language feature from PAHA auth organization creation
- Fix tests