### PR TITLE
REKDAT-393: Upgrade CKAN to 2.10.6

### DIFF
--- a/ckan/ckan-requirements.in
+++ b/ckan/ckan-requirements.in
@@ -1,8 +1,7 @@
 # This file defines the used CKAN version and any overrides
 # Compile with pip-compile to produce the ckan-requirements.txt used in build
 
-ckan[requirements]==2.10.5
+ckan[requirements]==2.10.6
 
 # Runtime requirements
 uWSGI==2.0.26
-gevent==24.2.1

--- a/ckan/ckan-requirements.txt
+++ b/ckan/ckan-requirements.txt
@@ -22,7 +22,8 @@ charset-normalizer==2.0.12
     # via
     #   ckan
     #   requests
-ckan==2.10.6
+# Removed manually for installing editable separately
+# ckan==2.10.6
     # via -r ckan-requirements.in
 click==8.1.3
     # via

--- a/ckan/ckan-requirements.txt
+++ b/ckan/ckan-requirements.txt
@@ -2,7 +2,7 @@
 #    uv pip compile ckan-requirements.in --unsafe-package setuptools --python-version 3.10.12
 alembic==1.8.1
     # via ckan
-async-timeout==4.0.3
+async-timeout==5.0.1
     # via redis
 babel==2.10.3
     # via
@@ -22,8 +22,7 @@ charset-normalizer==2.0.12
     # via
     #   ckan
     #   requests
-# Removed manually for installing editable separately
-#ckan==2.10.5
+ckan==2.10.6
     # via -r ckan-requirements.in
 click==8.1.3
     # via
@@ -53,12 +52,9 @@ flask-wtf==1.0.1
     # via ckan
 funcsigs==1.0.2
     # via beaker
-gevent==24.2.1
-    # via -r ckan-requirements.in
 greenlet==2.0.2
     # via
     #   ckan
-    #   gevent
     #   sqlalchemy
 idna==3.7
     # via
@@ -215,12 +211,8 @@ zipp==3.19.1
     # via
     #   ckan
     #   importlib-metadata
-zope-event==5.0
-    # via gevent
 zope-interface==5.4.0
-    # via
-    #   ckan
-    #   gevent
+    # via ckan
 
 # The following packages were excluded from the output:
 # setuptools


### PR DESCRIPTION
- Change CKAN version to 2.10.6 in ckan-requirements.in
- Remove gevent requirement in ckan-requirements.in (conflicts with CKAN requirements)
- Regenerate ckan-requirements.txt