### PR TITLE
REKDAT-465: paha authorized endpoint

### DIFF
--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/model.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/model.py
@@ -69,3 +69,9 @@ class PahaAuthenticationToken(toolkit.BaseModel):
                 .filter(cls.secret == secret)
                 .where(cls.expires > now)
                 .first())
+
+    @classmethod
+    def invalidate(cls, id):
+        matching = meta.Session.query(cls).filter(id == id).one()
+        meta.Session.delete(matching)
+        meta.Session.commit()

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/plugin.py
@@ -4,16 +4,13 @@ import logging
 import json
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
-import ckan.model as model
 from ckan.logic import NotFound
 from ckanext.pages.interfaces import IPagesSchema
 from ckan.lib.plugins import DefaultTranslation
 from flask import has_request_context
 from ckanext.restricteddata.cli import cli
-from ckanext.restricteddata.model import PahaAuthenticationToken
 from collections import OrderedDict
 
-from flask import request
 from typing import Optional
 
 from . import helpers, validators, views
@@ -348,7 +345,6 @@ def filter_allowed_resources(resources: List[ResourceDict],
 
 class RestrictedDataPahaAuthenticationPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.interfaces.IActions)
-    plugins.implements(plugins.interfaces.IAuthenticator, inherit=True)
 
     def get_actions(self):
         return {
@@ -357,19 +353,6 @@ class RestrictedDataPahaAuthenticationPlugin(plugins.SingletonPlugin):
             'purge_expired_temporary_memberships': action.purge_expired_temporary_memberships,
             'purge_expired_paha_auth_tokens': action.purge_expired_paha_auth_tokens,
         }
-
-    def identify(self):
-        auth_header = next((v for k, v in request.headers if k == 'Authorization'), None)
-        if auth_header:
-            token = PahaAuthenticationToken.get(auth_header)
-            if token is not None:
-                user = model.User.get(token.user_id)
-                toolkit.g.user = user.name
-                toolkit.g.userobj = user
-                toolkit.login_user(user)
-                return
-
-        return super().identify()
 
 # NOTE: DO NOT ENABLE THIS PLUGIN IN NON-LOCAL ENVIRONMENTS
 class RestrictedDataResetPlugin(plugins.SingletonPlugin):

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/tests/test_plugin.py
@@ -630,8 +630,9 @@ def test_paha_authentication_logs_in_user(app):
 
     # Use the token to log in
     client = app.test_client(use_cookies=True)
-    headers={'Authorization': auth_token}
-    response = client.get(toolkit.url_for("user.read", id=some_user['name']), headers=headers)
+    response = client.get(toolkit.url_for("paha.authorized", token=auth_token))
+    assert response.status_code == 200
+    response = client.get(toolkit.url_for("user.read", id=some_user['name']))
     assert response.status_code == 200
     assert some_user['fullname'] in response.body
 
@@ -666,8 +667,7 @@ def test_paha_authentication_grants_temporary_membership(app):
 
     # Log in and open organization edit view
     client = app.test_client(use_cookies=True)
-    headers={'Authorization': auth_token}
-    response = client.get(toolkit.url_for("organization.edit", id=organization['name']), headers=headers)
+    response = client.get(toolkit.url_for("paha.authorized", token=auth_token))
     assert response.status_code == 200
 
     # Use same session to open user dashboard view
@@ -705,9 +705,8 @@ def test_paha_auth_token_expiry(app):
 
     # Use the token to try to log in
     client = app.test_client()
-    headers={'Authorization': auth_token}
-    response = client.get(toolkit.url_for("organization.edit", id=organization['id']), headers=headers)
-    assert response.status_code == 403
+    response = client.get(toolkit.url_for("paha.authorized", token=auth_token))
+    assert response.status_code == 400
 
 @pytest.mark.usefixtures("with_plugins", "clean_db", "with_request_context")
 def test_temporary_membership_expiry(app):

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/views.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/views.py
@@ -1,6 +1,8 @@
 from ckan.plugins import toolkit
+from ckan.model import User
 from ckan.views.dataset import GroupView as CkanDatasetGroupView
 from flask import Blueprint, make_response
+from ckanext.restricteddata.model import PahaAuthenticationToken
 import logging
 
 log = logging.getLogger(__name__)
@@ -46,7 +48,21 @@ def authorize():
         headers = {'Content-Type': 'application/json'}
         return make_response(body, 400, headers)
 
+
+def authorized():
+    token_value = toolkit.get_or_bust(toolkit.request.params, 'token')
+    token = PahaAuthenticationToken.get(token_value)
+    if token is None:
+        toolkit.abort(400, "Missing token")
+
+    user = User.get(token.user_id)
+    toolkit.g.user = user.name
+    toolkit.g.userobj = user
+    toolkit.login_user(user)
+    return toolkit.h.redirect_to('activity.dashboard')
+
 paha.add_url_rule('/authorize', view_func=authorize, methods=['POST'])
+paha.add_url_rule('/authorized', view_func=authorized, methods=['GET'])
 
 def get_blueprints():
     return [ns, restricted_data_dataset, paha]

--- a/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/views.py
+++ b/ckan/ckanext/ckanext-restricteddata/ckanext/restricteddata/views.py
@@ -54,8 +54,9 @@ def authorized():
     token = PahaAuthenticationToken.get(token_value)
     if token is None:
         toolkit.abort(400, "Missing token")
-
     user = User.get(token.user_id)
+    PahaAuthenticationToken.invalidate(token.id)
+
     toolkit.g.user = user.name
     toolkit.g.userobj = user
     toolkit.login_user(user)


### PR DESCRIPTION
- Removed `IAuthenticator` implementation in `RestrictedDataPahaAuthenticationPlugin`
- Added `paha.authorized` endpoint for logging in with an authentication token as a GET parameter
- Invalidate token after it is used to successfully log in