### PR TITLE
Only IP-restrict /paha/authorize path to allow clients to /paha/authorized

### DIFF
--- a/docker/nginx/jinja2-templates/server.conf.j2
+++ b/docker/nginx/jinja2-templates/server.conf.j2
@@ -50,8 +50,8 @@ location ~ ^/(.*)$ {
     add_header Cache-Control private;
   }
 
-  location ~ ^/paha/(.*)$ {
-    proxy_pass http://$ckan_target/paha/$1$is_args$args;
+  location ~ ^/paha/authorize$ {
+    proxy_pass http://$ckan_target/paha/authorize$is_args$args;
 
     # Process proxy address list into allow directives
     {% for ip in proxy_addresses.split(',') %}


### PR DESCRIPTION
- Previously the nginx configuration blocked all /paha paths from untrusted sources, but the new authorization flow requires clients access /paha/authorized. Now blocking only /paha/authorize is required