### PR TITLE
Try to wait for document load before testing that page has changed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,6 +99,7 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false
           tags: |
             ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ matrix.name }}:${{ github.sha }}
             ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ matrix.name }}:latest

--- a/robot/tests/category.robot
+++ b/robot/tests/category.robot
@@ -58,5 +58,5 @@ Remove Category
     Scroll To Form Actions
     Click Link  link:Poista
     Click Suomi.fi Dialog Button  Vahvista
-    Wait Until Location Is Not  /group/edit/testikategoria
+    Wait For Condition	return document.readyState == "complete"
     URL Path Should Be  /group/

--- a/robot/tests/producer.robot
+++ b/robot/tests/producer.robot
@@ -35,7 +35,7 @@ Remove Producer
     Scroll To Form Actions
     Click Link  link:Poista
     Click Suomi.fi Dialog Button  Vahvista
-    Wait Until Location Is Not  /organization/edit/testiorganisaatio
+    Wait For Condition	return document.readyState == "complete"
     URL Path Should Be  /organization/
 
 *** Keywords ***


### PR DESCRIPTION
CKAN version test fails as test has been updated but the new container has not been pushed due to flaky test in master.

Adds provenance configuration as in https://github.com/vrk-kpa/opendata/pull/2714