### PR TITLE
Upgrade python and alpine

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -1,11 +1,10 @@
 # build args
 ARG SECRET_NPMRC
-ARG BASE_IMAGE=public.ecr.aws/docker/library/python:3.10.17-alpine3.21
 
 #
 # Add common configuration to base image
 #
-FROM ${BASE_IMAGE} AS configured_base
+FROM public.ecr.aws/docker/library/python:3.10.17-alpine3.21 AS configured_base
 
 ENV APP_DIR=/srv/app
 ENV SRC_DIR=${APP_DIR}/src

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -1,6 +1,6 @@
 # build args
 ARG SECRET_NPMRC
-ARG BASE_IMAGE=public.ecr.aws/docker/library/python:3.10.12-alpine3.18
+ARG BASE_IMAGE=public.ecr.aws/docker/library/python:3.10.17-alpine3.21
 
 #
 # Add common configuration to base image


### PR DESCRIPTION
Upgrades alpine to fix some security hub warnings, updates python to latest 3.10 version. Python 3.12 requires updated ckan or at least its dependancies.

Moves base image version out of the variable as dependabot seems to disregard it in variable.