### PR TITLE
Add missing policy to build role

### DIFF
--- a/cloudformation/github-actions-stack.yml
+++ b/cloudformation/github-actions-stack.yml
@@ -135,6 +135,7 @@ Resources:
                   - "ecr:InitiateLayerUpload"
                   - "ecr:PutImage"
                   - "ecr:UploadLayerPart"
+                  - "ecr:DescribeImages"
                 Resource: !Ref ECRRepositoryArn
 
   ScanRole:


### PR DESCRIPTION
Build role needs descibe images to fetch information if the current prod-images are already tagged with prod-prefix or not.